### PR TITLE
[SW] Fix FFT performance

### DIFF
--- a/sw/spatzBenchmarks/dp-fft/main.c
+++ b/sw/spatzBenchmarks/dp-fft/main.c
@@ -114,6 +114,7 @@ int main() {
 
   // Display runtime
   if (cid == 0) {
+    // See the bottom of the file for additional info on the performance calculation
     long unsigned int performance =
         1000 * 5 * NFFT * log2_nfft / timer;
     long unsigned int utilization =
@@ -146,3 +147,23 @@ int main() {
 
   return 0;
 }
+
+// Comments on performance calculation:
+// Number of mathematical operations: 5 * NFFT * log2(NFFT)
+// Each fp-add, fp-mul, fp-sub, fp-div corresponds to a floating-point operation
+// and can be executed in one cycle by each FPU.
+// Instead, macc-like instructions, i.e. multiply-and-accumulate, correspond to two operations
+// and an FPU can compute one macc instruction per cycle, i.e., two fp-operations per cycle in this case.
+
+// Max perf: 5/4 * #FPUs [DP-FLOP/cycle] -> we replace the 5/4 with the equivalent 1250/1000
+// Why the 5/4 factor?
+// If we had only macc-like instructions in the kernel, the max throughput would be 2 DP-FLOP/(cycle)
+// for each FPU.
+// Instead, if we only had non-macc instructions in the kernel, the max throughput would be 1 DP-FLOP/(cycle)
+// for each FPU.
+// In an intermediate case, the value is between 2 and 1 DP-FLOP/(cycle) for each FPU.
+// The kernel loop is composed of 8 vector FP instructions. Two of them are macc-like and six are not.
+// Thus, in each loop and for a vector length of one element (the vector length gets simplified anyway),
+// we have 10 operations executed in 8 cycles in the best case possible with 100% utilization.
+// Therefore, the maximum performance at 100% utilization is 10/8 DP-FLOP/(cycle) per FPU, i.e.,
+// 5/4  DP-FLOP/(cycle) per FPU

--- a/sw/spatzBenchmarks/dp-fft/main.c
+++ b/sw/spatzBenchmarks/dp-fft/main.c
@@ -46,7 +46,8 @@ int main() {
   const unsigned int cid = snrt_cluster_core_idx();
 
   // log2(nfft).
-  const unsigned int log2_nfft = 31 - __builtin_clz(NFFT >> 1);
+  const unsigned int log2_nfft      = 31 - __builtin_clz(NFFT);
+  const unsigned int log2_half_nfft = 31 - __builtin_clz(NFFT >> 1);
 
   // Reset timer
   unsigned int timer = (unsigned int)-1;
@@ -57,7 +58,7 @@ int main() {
     buffer = (double *)snrt_l1alloc(2 * NFFT * sizeof(double));
     twiddle = (double *)snrt_l1alloc((2 * NTWI + NFFT) * sizeof(double));
     store_idx =
-        (uint16_t *)snrt_l1alloc(log2_nfft * (NFFT / 4) * sizeof(uint16_t));
+        (uint16_t *)snrt_l1alloc(log2_half_nfft * (NFFT / 4) * sizeof(uint16_t));
     bitrev = (uint16_t *)snrt_l1alloc((NFFT / 4) * sizeof(uint16_t));
   }
 
@@ -68,7 +69,7 @@ int main() {
     snrt_dma_start_1d(twiddle, twiddle_dram,
                       (2 * NTWI + NFFT) * sizeof(double));
     snrt_dma_start_1d(store_idx, store_idx_dram,
-                      log2_nfft * (NFFT / 4) * sizeof(uint16_t));
+                      log2_half_nfft * (NFFT / 4) * sizeof(uint16_t));
     snrt_dma_start_1d(bitrev, bitrev_dram, (NFFT / 4) * sizeof(uint16_t));
     snrt_dma_wait_all();
   }
@@ -98,7 +99,7 @@ int main() {
   snrt_cluster_hw_barrier();
 
   // Fall back into the single-core case
-  fft_sc(s_, buf_, twi_, store_idx, bitrev, NFFT >> 1, log2_nfft, cid);
+  fft_sc(s_, buf_, twi_, store_idx, bitrev, NFFT >> 1, log2_half_nfft, cid);
 
   // Wait for all cores to finish fft
   snrt_cluster_hw_barrier();
@@ -114,9 +115,9 @@ int main() {
   // Display runtime
   if (cid == 0) {
     long unsigned int performance =
-        1000 * 10 * NFFT * log2_nfft * 6 / 5 / timer;
+        1000 * 5 * NFFT * log2_nfft / timer;
     long unsigned int utilization =
-        performance / (2 * num_cores * SNRT_NFPU_PER_CORE);
+        (1000 * performance) / (1250 * num_cores * SNRT_NFPU_PER_CORE);
 
     printf("\n----- fft on %d samples -----\n", NFFT);
     printf("The execution took %u cycles.\n", timer);

--- a/sw/spatzBenchmarks/sp-fft/main.c
+++ b/sw/spatzBenchmarks/sp-fft/main.c
@@ -113,6 +113,7 @@ int main() {
 
   // Display runtime
   if (cid == 0) {
+    // See the bottom of the file dp-fft/main.c for further info on the performance calculation
     long unsigned int performance =
         1000 * 5 * NFFT * log2_nfft / timer;
     long unsigned int utilization =


### PR DESCRIPTION
HP: 
 - There are #FPUs in total in the architecture
 - Each FPU can compute `1 DP-FMACC` per cycle or `1 DP-FLOP` per cycle for every other operation
 - `1 DP-FMACC == 2 DP-FLOP` in terms of number of operations

```
64-bit FFT
#samples: `NFFT`
operations: 5 * NFFT * log2(NFFT) [DP-FLOP]
performance: operations / runtime [DP-FLOP/cycle]
max_performance: 5/4 * #FPUs [DP-FLOP/cycle]
utilization: 100 * performance / max_performance [%]
```

Notes:
To calculate the utilization using integer numbers, avoiding precision loss, we replace the `5/4` term with `1250/1000`:
```
1250/1000 = 1.25 = 5/4
```