### PR TITLE
Fix issue when setting `vl` with AVL=0xffffffff

### DIFF
--- a/hw/ip/spatz/src/spatz_controller.sv
+++ b/hw/ip/spatz/src/spatz_controller.sv
@@ -132,7 +132,7 @@ module spatz_controller
               default: vlmax = vlmax;
             endcase
 
-            vl_d = (spatz_req.rs1 == '1) ? (MAXVL >> spatz_req.vtype.vsew) : (int'(vlmax) < spatz_req.rs1) ? vlmax : spatz_req.rs1;
+            vl_d = (int'(vlmax) < spatz_req.rs1) ? vlmax : spatz_req.rs1;
           end else begin
             // Keep vl mode
 

--- a/sw/riscvTests/CMakeLists.txt
+++ b/sw/riscvTests/CMakeLists.txt
@@ -27,6 +27,8 @@ include_directories(isa/macros/vector)
 enable_testing()
 set(SNITCH_TEST_PREFIX riscvTests-)
 
+add_snitch_test(vsetvli isa/rv64uv/vsetvli.c)
+
 add_snitch_test(vadd  isa/rv64uv/vadd.c)
 add_snitch_test(vsub  isa/rv64uv/vsub.c)
 add_snitch_test(vrsub isa/rv64uv/vrsub.c)

--- a/sw/riscvTests/isa/macros/vector/vector_macros.h
+++ b/sw/riscvTests/isa/macros/vector/vector_macros.h
@@ -122,7 +122,7 @@ int test_case;
 // Check the result against a scalar golden value
 #define XCMP(casenum, act, exp)                                                \
   if (act != exp) {                                                            \
-    printf("FAILED. Got %d, expected %d.\n", casenum, act, exp);               \
+    printf("[TC %d] FAILED. Got %d, expected %d.\n", casenum, act, exp);       \
     num_failed++;                                                              \
     return;                                                                    \
   }                                                                            \
@@ -131,7 +131,7 @@ int test_case;
 // Check the result against a floating-point scalar golden value
 #define FCMP(casenum, act, exp)                                                \
   if (act != exp) {                                                            \
-    printf("FAILED. Got %lf, expected %lf.\n", casenum, act, exp);             \
+    printf("[TC %d] FAILED. Got %lf, expected %lf.\n", casenum, act, exp);     \
     num_failed++;                                                              \
     return;                                                                    \
   }                                                                            \

--- a/sw/riscvTests/isa/rv64uv/vsetvli.c
+++ b/sw/riscvTests/isa/rv64uv/vsetvli.c
@@ -44,11 +44,21 @@ void TEST_CASE1() {
   XCMP(7, vl, snrt_min(avl, vlenb * 2 / 2));
 }
 
+void TEST_CASE2() {
+  uint32_t vl, avl;
+  uint32_t vlenb = read_csr(vlenb);
+
+  avl = 0xFFFFFFFF;
+  __asm__ volatile("vsetvli %[vl], %[avl], e8, m1, ta, ma" : [vl]"=r"(vl) : [avl] "r"(avl));
+  XCMP(8, vl, vlenb);
+}
+
 int main(void) {
   INIT_CHECK();
   enable_vec();
 
   TEST_CASE1();
+  TEST_CASE2();
 
   EXIT_CHECK();
 }

--- a/sw/riscvTests/isa/rv64uv/vsetvli.c
+++ b/sw/riscvTests/isa/rv64uv/vsetvli.c
@@ -4,26 +4,51 @@
 //
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Max Wipfli <mwipfli@ethz.ch>
 
+#include "encoding.h"
 #include "vector_macros.h"
 #include <stdint.h>
+
+void TEST_CASE1() {
+  uint32_t vl, avl;
+  uint32_t vlenb = read_csr(vlenb);
+
+  avl = 314;
+  __asm__ volatile("vsetvli %[vl], %[avl], e8, m2, ta, ma" : [vl]"=r"(vl) : [avl] "r"(avl));
+  XCMP(1, vl, snrt_min(avl, vlenb * 2));
+
+  avl = 15;
+  __asm__ volatile("vsetvli %[vl], %[avl], e16, m2, ta, ma" : [vl]"=r"(vl) : [avl] "r"(avl));
+  XCMP(2, vl, snrt_min(avl, vlenb * 2 / 2));
+
+  avl = 255;
+  __asm__ volatile("vsetvli %[vl], %[avl], e32, m2, ta, ma" : [vl]"=r"(vl) : [avl] "r"(avl));
+  XCMP(3, vl, snrt_min(avl, vlenb * 2 / 4));
+
+  avl = 69;
+  __asm__ volatile("vsetvli %[vl], %[avl], e64, m8, ta, ma" : [vl]"=r"(vl) : [avl] "r"(avl));
+  XCMP(4, vl, snrt_min(avl, vlenb * 8 / 8));
+
+  // SEW=128 not supported
+  // avl = 69;
+  // __asm__ volatile("vsetvli %[vl], %[avl], e128, m8, ta, ma" : [vl]"=r"(vl) : [avl] "r"(avl));
+  // XCMP(5, vl, snrt_min(avl, vlenb * 2 / 16));
+
+  avl = 15;
+  __asm__ volatile("vsetvli %[vl], %[avl], e8, m8, ta, ma" : [vl]"=r"(vl) : [avl] "r"(avl));
+  XCMP(6, vl, snrt_min(avl, vlenb * 8));
+
+  avl = 10000;
+  __asm__ volatile("vsetvli %[vl], %[avl], e16, m2, ta, ma" : [vl]"=r"(vl) : [avl] "r"(avl));
+  XCMP(7, vl, snrt_min(avl, vlenb * 2 / 2));
+}
 
 int main(void) {
   INIT_CHECK();
   enable_vec();
-  uint64_t scalar = 314;
-  __asm__ volatile("vsetvli t0, %[A], e8, m2" ::[A] "r"(scalar));
-  scalar = 15;
-  __asm__ volatile("vsetvli t0, %[A], e16, m2" ::[A] "r"(scalar));
-  scalar = 255;
-  __asm__ volatile("vsetvli t0, %[A], e32, m2" ::[A] "r"(scalar));
-  scalar = 69;
-  __asm__ volatile("vsetvli t0, %[A], e64, m8" ::[A] "r"(scalar));
-  scalar = 69;
-  __asm__ volatile("vsetvli t0, %[A], e128, m8" ::[A] "r"(scalar));
-  scalar = 15;
-  __asm__ volatile("vsetvli t0, %[A], e8, m8" ::[A] "r"(scalar));
-  scalar = 10000;
-  __asm__ volatile("vsetvli t0, %[A], e16, m2" ::[A] "r"(scalar));
-  return (0);
+
+  TEST_CASE1();
+
+  EXIT_CHECK();
 }


### PR DESCRIPTION
When giving AVL=0xffffffff (-1) to `vsetvli`, `vl` was previously set to an erroneous length (longer than VLMAX = LMUL*VLEN/SEW).

Example:
* VLEN = 512, LMUL = 1, SEW = 8
* Then, VLMAX = 64 elements.
* The previous code would then set `vl` to 512, which is obviously wrong.

Given that there was a special case in the RTL for `rs1 = '1`, I was searching for such a special case in the RVV spec. However, I couldn't find one, neither in v0.7 nor v1.0.

This code also adds a `vetsetvli` test that actually tests something and adds a test case to check for this.