### PR TITLE
Mask scalar result based on correct instruction metadata

### DIFF
--- a/hw/ip/spatz/src/spatz_vfu.sv
+++ b/hw/ip/spatz/src/spatz_vfu.sv
@@ -274,7 +274,7 @@ module spatz_vfu
       vfu_rsp_o.id      = result_tag.id;
       vfu_rsp_o.rd      = result_tag.vd_addr[GPRWidth-1:0];
       vfu_rsp_o.wb      = result_tag.wb;
-      vfu_rsp_o.result  = scalar_result;
+      vfu_rsp_o.result  = result_tag.wb ? scalar_result : '0;
       vfu_rsp_valid_o   = 1'b1;
     end
   end: control_proc
@@ -333,7 +333,7 @@ module spatz_vfu
   assign result       = state_q == VFU_RunningIPU ? ipu_result       : fpu_result;
   assign result_valid = state_q == VFU_RunningIPU ? ipu_result_valid : fpu_result_valid;
 
-  assign scalar_result = spatz_req.op_arith.is_scalar ? result[ELEN-1:0] : '0;
+  assign scalar_result = result[ELEN-1:0];
 
   ///////////////////////
   //  Reduction logic  //


### PR DESCRIPTION
For VFU instructions with scalar results (e.g., scalar floating point instructions) immediately followed by VFU instructions that commit to the VRF, the first instruction could write back a zero result to the FP register file. (This was maybe similar for the GP register file, but I haven't checked).

This happened because the scalar result was masked based on the `is_scalar` flag from the instruction currently in the operation queue (i.e., earlier in the pipeline). If this was an instruction with a vector result, it's `is_scalar` flag would be cleared and the scalar result masked.

This changes it so it considers the correct instruction (i.e., it takes the information from the result tag's `wb` bit).