### PR TITLE
spatz_fpu_sequencer: Fix handshake when committing FPU moves

### DIFF
--- a/hw/ip/spatz/src/spatz_fpu_sequencer.sv
+++ b/hw/ip/spatz/src/spatz_fpu_sequencer.sv
@@ -738,8 +738,8 @@ module spatz_fpu_sequencer
     // Commit a move result
     else if (fp_move_result_valid_o) begin
       resp_o                 = fp_move_result_o;
-      resp_valid_o           = 1'b1;
-      fp_move_result_ready_i = 1'b1;
+      resp_valid_o           = fp_move_result_valid_o;
+      fp_move_result_ready_i = resp_ready_i;
     end
 
     // Commit a FP LSU response


### PR DESCRIPTION
This previously broke if Snitch was not ready for the response, and the response would be dropped.

This fix makes it better, but still not perfect. If a Spatz response arrives while the FPU's response is pending, the Spatz response would take precedence. This would mean that data isn't stable while valid is asserted, which violates the handshake semantics.