### PR TITLE
spatz_fpu_sequencer: Actually allow multiple outstanding loads

### DIFF
--- a/hw/ip/snitch/src/snitch_lsu.sv
+++ b/hw/ip/snitch/src/snitch_lsu.sv
@@ -8,6 +8,9 @@
 /// `NumOutstandingMem` requests in total) and optionally NaNBox if used in a
 /// floating-point setting. It expects its memory sub-system to keep order (as if
 /// issued with a single ID).
+
+`include "common_cells/assertions.svh"
+
 module snitch_lsu #(
   parameter int unsigned AddrWidth           = 32,
   parameter int unsigned DataWidth           = 32,
@@ -177,5 +180,12 @@ module snitch_lsu #(
   // without ans answer to the core.
   assign lsu_pvalid_o = data_rsp_i.p_valid & ~mem_out;
   assign data_req_o.p_ready = lsu_pready_i | mem_out;
+
+  // ----------
+  // Assertions
+  // ----------
+  // It is a waste of resources to configure more outstanding loads than outstanding memory
+  // transactions, as this means the load address queue FIFO can never be fully used.
+  `ASSERT_INIT(CheckOutstandingConfig, NumOutstandingLoads <= NumOutstandingMem);
 
 endmodule

--- a/hw/ip/spatz/src/spatz_fpu_sequencer.sv
+++ b/hw/ip/spatz/src/spatz_fpu_sequencer.sv
@@ -530,6 +530,7 @@ module spatz_fpu_sequencer
     .dreq_t             (dreq_t             ),
     .drsp_t             (drsp_t             ),
     .DataWidth          (FLEN               ),
+    .NumOutstandingMem  (NumOutstandingLoads),
     .NumOutstandingLoads(NumOutstandingLoads)
   ) i_fp_lsu (
     .clk_i        (clk_i           ),


### PR DESCRIPTION
Previously, the FPU sequencer was restricted to a single outstanding loads by the default value of the `NrOutstandingMem` parameter in `snitch_lsu`. This fixes the issue, making the FPU sequencer actually allow multiple outstanding loads. This can improve performance on kernels that do multiple scalar FP loads consecutively.

It also adds an `ASSERT_INIT()` check to `snitch_lsu` to check for this bad configuration, which only wastes resources as the load address queue FIFO is oversized in case `NrOutstandingLoads > NrOutstandingMem`.