### PR TITLE
spatz_vlsu: Increase depth of i_fifo_commit_insn

### DIFF
--- a/hw/ip/spatz/src/spatz_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_vlsu.sv
@@ -314,9 +314,9 @@ module spatz_vlsu
   logic             commit_insn_valid;
 
   fifo_v3 #(
-    .DEPTH       (3                ),
-    .FALL_THROUGH(1'b1             ),
-    .dtype       (commit_metadata_t)
+    .DEPTH       (NrParallelInstructions),
+    .FALL_THROUGH(1'b1                  ),
+    .dtype       (commit_metadata_t     )
   ) i_fifo_commit_insn (
     .clk_i     (clk_i            ),
     .rst_ni    (rst_ni           ),


### PR DESCRIPTION
This was previously undersized if too many short VLSU instructions were executed in series. The controller ensures that only `NrParallelInstructions` are in flight at any time (as it allocates unique IDs to them), so this is the maximum depth needed.