### PR TITLE
Fix and generalize `dotp` to non-power-of-2

### DIFF
--- a/hw/ip/spatz/src/spatz_decoder.sv
+++ b/hw/ip/spatz/src/spatz_decoder.sv
@@ -783,7 +783,7 @@ module spatz_decoder
               // vmv is the same as a zero slide
               spatz_req.op                 = VSLIDEUP;
               spatz_req.ex_unit            = SLD;
-              spatz_req.op_sld.insert      = (func3 == OPIVI || func3 == OPIVX);
+              spatz_req.op_sld.insert      = (func3 == OPIVI || func3 == OPIVX || func3 == OPMVX);
               spatz_req.op_sld.vmv         = 1'b1;
               spatz_req.vs2                = spatz_req.vs1;
               spatz_req.use_vs2            = func3 != OPIVI || decoder_req_i.instr inside {riscv_instr::VMV_S_X};

--- a/sw/spatzBenchmarks/dp-fdotp/kernel/fdotp.c
+++ b/sw/spatzBenchmarks/dp-fdotp/kernel/fdotp.c
@@ -26,6 +26,7 @@ double fdotp_v64b(const double *a, const double *b, unsigned int avl) {
   double red;
 
   // Clean the accumulator
+  asm volatile("vsetvli %0, %1, e64, m8, ta, ma" : "=r"(vl) : "r"(avl));
   asm volatile("vmv.s.x v0, zero");
 
   // Stripmine and accumulate a partial reduced vector
@@ -51,6 +52,7 @@ double fdotp_v64b(const double *a, const double *b, unsigned int avl) {
   } while (avl > 0);
 
   // Reduce and return
+  asm volatile("vsetvli zero, %0, e64, m8, ta, ma" :: "r"(orig_avl));
   asm volatile("vfredusum.vs v0, v24, v0");
   asm volatile("vfmv.f.s %0, v0" : "=f"(red));
 
@@ -63,6 +65,9 @@ float fdotp_v32b(const float *a, const float *b, unsigned int avl) {
   unsigned int vl;
 
   float red;
+
+  asm volatile("vsetvli %0, %1, e32, m8, ta, ma" : "=r"(vl) : "r"(avl));
+  asm volatile("vmv.s.x v0, zero");
 
   // Stripmine and accumulate a partial reduced vector
   do {
@@ -87,6 +92,7 @@ float fdotp_v32b(const float *a, const float *b, unsigned int avl) {
   } while (avl > 0);
 
   // Reduce and return
+  asm volatile("vsetvli zero, %0, e32, m8, ta, ma" :: "r"(orig_avl));
   asm volatile("vfredusum.vs v0, v24, v0");
   asm volatile("vfmv.f.s %0, v0" : "=f"(red));
   return red;
@@ -98,6 +104,9 @@ _Float16 fdotp_v16b(const _Float16 *a, const _Float16 *b, unsigned int avl) {
   unsigned int vl;
 
   _Float16 red;
+
+  asm volatile("vsetvli %0, %1, e16, m8, ta, ma" : "=r"(vl) : "r"(avl));
+  asm volatile("vmv.s.x v0, zero");
 
   // Stripmine and accumulate a partial reduced vector
   do {
@@ -122,6 +131,7 @@ _Float16 fdotp_v16b(const _Float16 *a, const _Float16 *b, unsigned int avl) {
   } while (avl > 0);
 
   // Reduce and return
+  asm volatile("vsetvli zero, %0, e16, m8, ta, ma" :: "r"(orig_avl));
   asm volatile("vfredusum.vs v0, v24, v0");
   asm volatile("vfmv.f.s %0, v0" : "=f"(red));
   return red;


### PR DESCRIPTION
Fix `dotp` kernel and `vmv.s.x` hardware decoding.

1) `vl != 0` before `vm.s.x`.
2) Set up `vl` correctly before reduction to accomodate `avl` non multiple of `VLEN`, e.g. non-power-of-2 `vl`.
3) Add accumulator initialization to 32 and 16 bit `dotp`.
4) Fix `vmv.s.x` decoding.