### PR TITLE
Extend EOC-and-return-value register to 32b and modify the runtime to save the return value there

### DIFF
--- a/hw/ip/spatz/src/spatz_decoder.sv
+++ b/hw/ip/spatz/src/spatz_decoder.sv
@@ -855,7 +855,7 @@ module spatz_decoder
               // vmv is the same as a zero slide
               spatz_req.op                 = VSLIDEUP;
               spatz_req.ex_unit            = SLD;
-              spatz_req.op_sld.insert      = (func3 == OPIVI || func3 == OPIVX);
+              spatz_req.op_sld.insert      = (func3 == OPIVI || func3 == OPIVX || func3 == OPMVX);
               spatz_req.op_sld.vmv         = 1'b1;
               spatz_req.vs2                = spatz_req.vs1;
               spatz_req.use_vs2            = func3 != OPIVI || decoder_req_i.instr inside {riscv_instr::VMV_S_X};

--- a/hw/system/spatz_cluster/src/spatz_cluster_peripheral/spatz_cluster_peripheral_reg.hjson
+++ b/hw/system/spatz_cluster/src/spatz_cluster_peripheral/spatz_cluster_peripheral_reg.hjson
@@ -446,7 +446,7 @@
         hwaccess: "hro",
         resval: "0",
         fields: [{
-            bits: "0:0",
+            bits: "31:0",
             name: "EOC_EXIT",
             desc: "Indicates the end of computation and exit status."
         }]

--- a/hw/system/spatz_cluster/src/spatz_cluster_peripheral/spatz_cluster_peripheral_reg_pkg.sv
+++ b/hw/system/spatz_cluster/src/spatz_cluster_peripheral/spatz_cluster_peripheral_reg_pkg.sv
@@ -152,7 +152,7 @@ package spatz_cluster_peripheral_reg_pkg;
   } spatz_cluster_peripheral_reg2hw_cluster_boot_control_reg_t;
 
   typedef struct packed {
-    logic        q;
+    logic [31:0] q;
   } spatz_cluster_peripheral_reg2hw_cluster_eoc_exit_reg_t;
 
   typedef struct packed {
@@ -200,17 +200,17 @@ package spatz_cluster_peripheral_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spatz_cluster_peripheral_reg2hw_perf_counter_enable_mreg_t [1:0] perf_counter_enable; // [358:297]
-    spatz_cluster_peripheral_reg2hw_hart_select_mreg_t [1:0] hart_select; // [296:277]
-    spatz_cluster_peripheral_reg2hw_perf_counter_mreg_t [1:0] perf_counter; // [276:179]
-    spatz_cluster_peripheral_reg2hw_cl_clint_set_reg_t cl_clint_set; // [178:146]
-    spatz_cluster_peripheral_reg2hw_cl_clint_clear_reg_t cl_clint_clear; // [145:113]
-    spatz_cluster_peripheral_reg2hw_hw_barrier_reg_t hw_barrier; // [112:81]
-    spatz_cluster_peripheral_reg2hw_icache_prefetch_enable_reg_t icache_prefetch_enable; // [80:80]
-    spatz_cluster_peripheral_reg2hw_spatz_status_reg_t spatz_status; // [79:79]
-    spatz_cluster_peripheral_reg2hw_spatz_cycle_reg_t spatz_cycle; // [78:47]
-    spatz_cluster_peripheral_reg2hw_cluster_boot_control_reg_t cluster_boot_control; // [46:15]
-    spatz_cluster_peripheral_reg2hw_cluster_eoc_exit_reg_t cluster_eoc_exit; // [14:14]
+    spatz_cluster_peripheral_reg2hw_perf_counter_enable_mreg_t [1:0] perf_counter_enable; // [389:328]
+    spatz_cluster_peripheral_reg2hw_hart_select_mreg_t [1:0] hart_select; // [327:308]
+    spatz_cluster_peripheral_reg2hw_perf_counter_mreg_t [1:0] perf_counter; // [307:210]
+    spatz_cluster_peripheral_reg2hw_cl_clint_set_reg_t cl_clint_set; // [209:177]
+    spatz_cluster_peripheral_reg2hw_cl_clint_clear_reg_t cl_clint_clear; // [176:144]
+    spatz_cluster_peripheral_reg2hw_hw_barrier_reg_t hw_barrier; // [143:112]
+    spatz_cluster_peripheral_reg2hw_icache_prefetch_enable_reg_t icache_prefetch_enable; // [111:111]
+    spatz_cluster_peripheral_reg2hw_spatz_status_reg_t spatz_status; // [110:110]
+    spatz_cluster_peripheral_reg2hw_spatz_cycle_reg_t spatz_cycle; // [109:78]
+    spatz_cluster_peripheral_reg2hw_cluster_boot_control_reg_t cluster_boot_control; // [77:46]
+    spatz_cluster_peripheral_reg2hw_cluster_eoc_exit_reg_t cluster_eoc_exit; // [45:14]
     spatz_cluster_peripheral_reg2hw_cfg_l1d_spm_reg_t cfg_l1d_spm; // [13:4]
     spatz_cluster_peripheral_reg2hw_cfg_l1d_insn_reg_t cfg_l1d_insn; // [3:2]
     spatz_cluster_peripheral_reg2hw_l1d_spm_commit_reg_t l1d_spm_commit; // [1:1]
@@ -295,7 +295,7 @@ package spatz_cluster_peripheral_reg_pkg;
     4'b 0001, // index[10] SPATZ_CLUSTER_PERIPHERAL_SPATZ_STATUS
     4'b 1111, // index[11] SPATZ_CLUSTER_PERIPHERAL_SPATZ_CYCLE
     4'b 1111, // index[12] SPATZ_CLUSTER_PERIPHERAL_CLUSTER_BOOT_CONTROL
-    4'b 0001, // index[13] SPATZ_CLUSTER_PERIPHERAL_CLUSTER_EOC_EXIT
+    4'b 1111, // index[13] SPATZ_CLUSTER_PERIPHERAL_CLUSTER_EOC_EXIT
     4'b 0011, // index[14] SPATZ_CLUSTER_PERIPHERAL_CFG_L1D_SPM
     4'b 0001, // index[15] SPATZ_CLUSTER_PERIPHERAL_CFG_L1D_INSN
     4'b 0001, // index[16] SPATZ_CLUSTER_PERIPHERAL_L1D_SPM_COMMIT

--- a/hw/system/spatz_cluster/src/spatz_cluster_peripheral/spatz_cluster_peripheral_reg_top.sv
+++ b/hw/system/spatz_cluster/src/spatz_cluster_peripheral/spatz_cluster_peripheral_reg_top.sv
@@ -284,8 +284,8 @@ module spatz_cluster_peripheral_reg_top #(
   logic [31:0] cluster_boot_control_qs;
   logic [31:0] cluster_boot_control_wd;
   logic cluster_boot_control_we;
-  logic cluster_eoc_exit_qs;
-  logic cluster_eoc_exit_wd;
+  logic [31:0] cluster_eoc_exit_qs;
+  logic [31:0] cluster_eoc_exit_wd;
   logic cluster_eoc_exit_we;
   logic [9:0] cfg_l1d_spm_qs;
   logic [9:0] cfg_l1d_spm_wd;
@@ -2170,9 +2170,9 @@ module spatz_cluster_peripheral_reg_top #(
   // R[cluster_eoc_exit]: V(False)
 
   prim_subreg #(
-    .DW      (1),
+    .DW      (32),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (32'h0)
   ) u_cluster_eoc_exit (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -2591,7 +2591,7 @@ module spatz_cluster_peripheral_reg_top #(
   assign cluster_boot_control_wd = reg_wdata[31:0];
 
   assign cluster_eoc_exit_we = addr_hit[13] & reg_we & !reg_error;
-  assign cluster_eoc_exit_wd = reg_wdata[0];
+  assign cluster_eoc_exit_wd = reg_wdata[31:0];
 
   assign cfg_l1d_spm_we = addr_hit[14] & reg_we & !reg_error;
   assign cfg_l1d_spm_wd = reg_wdata[9:0];
@@ -2724,7 +2724,7 @@ module spatz_cluster_peripheral_reg_top #(
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[0] = cluster_eoc_exit_qs;
+        reg_rdata_next[31:0] = cluster_eoc_exit_qs;
       end
 
       addr_hit[14]: begin

--- a/sw/snRuntime/include/l1cache.h
+++ b/sw/snRuntime/include/l1cache.h
@@ -16,3 +16,4 @@ void l1d_wait();
 void l1d_spm_config (uint32_t size);
 
 void set_eoc();
+void set_eoc_and_return_code (int eoc_and_return_code);

--- a/sw/snRuntime/src/l1cache.c
+++ b/sw/snRuntime/src/l1cache.c
@@ -66,8 +66,16 @@ void l1d_spm_config (uint32_t size) {
 }
 
 void set_eoc () {
+    // volatile uint32_t *eoc_reg =
+    // (uint32_t *)(_snrt_team_current->root->cluster_mem.end +
+    //             SPATZ_CLUSTER_PERIPHERAL_CLUSTER_EOC_EXIT_REG_OFFSET);
+    // *eoc_reg = 1;
+}
+
+// eoc_and_return_code[31:0] = {return_code[30:0], eoc};
+void set_eoc_and_return_code (int eoc_and_return_code) {
     volatile uint32_t *eoc_reg =
     (uint32_t *)(_snrt_team_current->root->cluster_mem.end +
                 SPATZ_CLUSTER_PERIPHERAL_CLUSTER_EOC_EXIT_REG_OFFSET);
-    *eoc_reg = 1;
+    *eoc_reg = eoc_and_return_code;
 }

--- a/sw/snRuntime/src/platforms/standalone/start_snitch.S
+++ b/sw/snRuntime/src/platforms/standalone/start_snitch.S
@@ -15,7 +15,7 @@ _snrt_exit:
     addi      sp, sp, -8
     sw        a0, 0(sp)
     sw        ra, 4(sp)
-    call      snrt_global_core_idx
+    call      snrt_cluster_core_idx
     # reload exit code into t0
     lw        t0, 0(sp)
     lw        ra, 4(sp)
@@ -29,8 +29,10 @@ _snrt_exit:
     ori       t0, t0, 1
     la        t1, tohost
     sw        t0, 0(t1)
+    mv        s0, t0
     call      l1d_flush
-    call      set_eoc
+    mv        a0, s0
+    call      set_eoc_and_return_code
 1:  ret
 
 # HTIF sections

--- a/sw/spatzBenchmarks/dp-fdotp/kernel/fdotp.c
+++ b/sw/spatzBenchmarks/dp-fdotp/kernel/fdotp.c
@@ -26,6 +26,7 @@ double fdotp_v64b(const double *a, const double *b, unsigned int avl) {
   double red;
 
   // Clean the accumulator
+  asm volatile("vsetvli %0, %1, e64, m8, ta, ma" : "=r"(vl) : "r"(avl));
   asm volatile("vmv.s.x v0, zero");
 
   // Stripmine and accumulate a partial reduced vector
@@ -51,6 +52,7 @@ double fdotp_v64b(const double *a, const double *b, unsigned int avl) {
   } while (avl > 0);
 
   // Reduce and return
+  asm volatile("vsetvli zero, %0, e64, m8, ta, ma" :: "r"(orig_avl));
   asm volatile("vfredusum.vs v0, v24, v0");
   asm volatile("vfmv.f.s %0, v0" : "=f"(red));
 
@@ -63,6 +65,9 @@ float fdotp_v32b(const float *a, const float *b, unsigned int avl) {
   unsigned int vl;
 
   float red;
+
+  asm volatile("vsetvli %0, %1, e32, m8, ta, ma" : "=r"(vl) : "r"(avl));
+  asm volatile("vmv.s.x v0, zero");
 
   // Stripmine and accumulate a partial reduced vector
   do {
@@ -87,6 +92,7 @@ float fdotp_v32b(const float *a, const float *b, unsigned int avl) {
   } while (avl > 0);
 
   // Reduce and return
+  asm volatile("vsetvli zero, %0, e32, m8, ta, ma" :: "r"(orig_avl));
   asm volatile("vfredusum.vs v0, v24, v0");
   asm volatile("vfmv.f.s %0, v0" : "=f"(red));
   return red;
@@ -98,6 +104,9 @@ _Float16 fdotp_v16b(const _Float16 *a, const _Float16 *b, unsigned int avl) {
   unsigned int vl;
 
   _Float16 red;
+
+  asm volatile("vsetvli %0, %1, e16, m8, ta, ma" : "=r"(vl) : "r"(avl));
+  asm volatile("vmv.s.x v0, zero");
 
   // Stripmine and accumulate a partial reduced vector
   do {
@@ -122,6 +131,7 @@ _Float16 fdotp_v16b(const _Float16 *a, const _Float16 *b, unsigned int avl) {
   } while (avl > 0);
 
   // Reduce and return
+  asm volatile("vsetvli zero, %0, e16, m8, ta, ma" :: "r"(orig_avl));
   asm volatile("vfredusum.vs v0, v24, v0");
   asm volatile("vfmv.f.s %0, v0" : "=f"(red));
   return red;

--- a/sw/spatzBenchmarks/dp-fdotp/main.c
+++ b/sw/spatzBenchmarks/dp-fdotp/main.c
@@ -172,7 +172,7 @@ int main() {
   }
 
   if (cid == 0)
-    if (fp_check(result[0], dotp_result*measure_iter)) {
+    if (fp_check(result[0], dotp_result)) {
     #ifdef PRINT_RESULT
       printf("Error: Result = %f, Golden = %f\n", result[0], dotp_result*measure_iter);
     #endif


### PR DESCRIPTION
Extend EOC-and-return-value register to 32b and modify the runtime to save the return value there.

The content of the `set_eoc` function has been commented out, as this is called in various Spatz kernels and would set the `eoc` flag before writing the return value in the corresponding register. If the eoc-and-return-value register is polled and evaluated when the `eoc` flag is set, it could happen that the return value register is checked before the return value gets written there.

This PR also includes the fix propose in #38 for the `vmv.x.s`  instruction. 
This fix makes sure that the accumulator is re-initialized to zero in the `fdotp` kernel at each iteration. Therefore, the final result does not depend on the number of iteration (this dependency has been removed).