### PR TITLE
Small bug fixes

### DIFF
--- a/hw/ip/snitch/src/snitch_lsu.sv
+++ b/hw/ip/snitch/src/snitch_lsu.sv
@@ -8,6 +8,9 @@
 /// `NumOutstandingMem` requests in total) and optionally NaNBox if used in a
 /// floating-point setting. It expects its memory sub-system to keep order (as if
 /// issued with a single ID).
+
+`include "common_cells/assertions.svh"
+
 module snitch_lsu #(
   parameter int unsigned AddrWidth           = 32,
   parameter int unsigned DataWidth           = 32,
@@ -177,5 +180,12 @@ module snitch_lsu #(
   // without ans answer to the core.
   assign lsu_pvalid_o = data_rsp_i.p_valid & ~mem_out;
   assign data_req_o.p_ready = lsu_pready_i | mem_out;
+
+// ----------
+  // Assertions
+  // ----------
+  // It is a waste of resources to configure more outstanding loads than outstanding memory
+  // transactions, as this means the load address queue FIFO can never be fully used.
+  `ASSERT_INIT(CheckOutstandingConfig, NumOutstandingLoads <= NumOutstandingMem);
 
 endmodule

--- a/hw/ip/spatz/src/spatz_fpu_sequencer.sv
+++ b/hw/ip/spatz/src/spatz_fpu_sequencer.sv
@@ -739,8 +739,8 @@ module spatz_fpu_sequencer
     // Commit a move result
     else if (fp_move_result_valid_o) begin
       resp_o                 = fp_move_result_o;
-      resp_valid_o           = 1'b1;
-      fp_move_result_ready_i = 1'b1;
+      resp_valid_o           = fp_move_result_valid_o;
+      fp_move_result_ready_i = resp_ready_i;
     end
 
     // Commit a FP LSU response

--- a/hw/ip/spatz/src/spatz_fpu_sequencer.sv
+++ b/hw/ip/spatz/src/spatz_fpu_sequencer.sv
@@ -530,6 +530,7 @@ module spatz_fpu_sequencer
     .dreq_t             (dreq_t             ),
     .drsp_t             (drsp_t             ),
     .DataWidth          (FLEN               ),
+    .NumOutstandingMem  (NumOutstandingLoads),
     .NumOutstandingLoads(NumOutstandingLoads)
   ) i_fp_lsu (
     .clk_i        (clk_i           ),

--- a/hw/ip/spatz/src/spatz_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_vlsu.sv
@@ -314,9 +314,9 @@ module spatz_vlsu
   logic             commit_insn_valid;
 
   fifo_v3 #(
-    .DEPTH       (3                ),
-    .FALL_THROUGH(1'b1             ),
-    .dtype       (commit_metadata_t)
+    .DEPTH       (NrParallelInstructions),
+    .FALL_THROUGH(1'b1                  ),
+    .dtype       (commit_metadata_t     )
   ) i_fifo_commit_insn (
     .clk_i     (clk_i            ),
     .rst_ni    (rst_ni           ),


### PR DESCRIPTION
1. Increase depth of i_fifo_commit_insn from 3 to NrParallelInstructions

- This was previously undersized if too many short VLSU instructions were executed in series. The controller ensures that only NrParallelInstructions are in flight at any time (as it allocates unique IDs to them), so this is the maximum depth needed.

2. Allow multiple outstanding loads by overriding default NrOutstandingMem parameter in i_fp_lsu

- Previously, the FPU sequencer was restricted to a single outstanding loads by the default value of the NrOutstandingMem parameter in snitch_lsu. This fixes the issue, making the FPU sequencer actually allow multiple outstanding loads. This can improve performance on kernels that do multiple scalar FP loads consecutively.
It also adds an ASSERT_INIT() check to snitch_lsu to check for this bad configuration, which only wastes resources as the load address queue FIFO is oversized in case NrOutstandingLoads > NrOutstandingMem.

4. Fix handshake when committing FPU moves

- This previously broke if Snitch was not ready for the response, and the response would be dropped. If a Spatz response arrives while the FPU's response is pending, the Spatz response would take precedence. This would mean that data isn't stable while valid is asserted, which violates the handshake semantics.

