### PR TITLE
[Decoder] Fix the VMV instruction for 32b system.

### DIFF
--- a/hw/ip/spatz/src/spatz_decoder.sv
+++ b/hw/ip/spatz/src/spatz_decoder.sv
@@ -843,6 +843,7 @@ module spatz_decoder
           spatz_req.vs2                = arith_s2;
           spatz_req.use_vs2            = 1'b1;
           spatz_req.op_arith.is_scalar = 1'b1;
+          spatz_req.vtype.vsew         = (ELEN == 32) ? EW_32 : EW_8;
         end
 
         // Vector floating-point instructions


### PR DESCRIPTION
The VMV instruction always assumes a 64-bit element to move. This commit adds an option that if the ELEN is 32b, it will set the vsew to 32b and expect only a 32b element to move, which is needed for 32b-based systems.