### PR TITLE
spatz_decoder: fix move instruction decoding

### DIFF
--- a/hw/ip/spatz/src/spatz_decoder.sv
+++ b/hw/ip/spatz/src/spatz_decoder.sv
@@ -786,7 +786,7 @@ module spatz_decoder
               spatz_req.op_sld.insert      = (func3 == OPIVI || func3 == OPIVX || func3 == OPMVX);
               spatz_req.op_sld.vmv         = 1'b1;
               spatz_req.vs2                = spatz_req.vs1;
-              spatz_req.use_vs2            = func3 != OPIVI || decoder_req_i.instr inside {riscv_instr::VMV_S_X};
+              spatz_req.use_vs2            = (func3 == OPIVV);
               spatz_req.op_arith.is_scalar = decoder_req_i.instr inside {riscv_instr::VMV_S_X};
             end
 
@@ -1110,7 +1110,7 @@ module spatz_decoder
                 spatz_req.rs1                = decoder_req_i.rs1;
                 spatz_req.use_vs1            = 1'b0;
                 spatz_req.vs2                = spatz_req.vs1;
-                spatz_req.use_vs2            = decoder_req_i.instr inside {riscv_instr::VFMV_S_F};
+                spatz_req.use_vs2            = 1'b0;
                 spatz_req.op_arith.is_scalar = decoder_req_i.instr inside {riscv_instr::VFMV_S_F};
               end
 

--- a/sw/riscvTests/isa/macros/vector/vector_macros.h
+++ b/sw/riscvTests/isa/macros/vector/vector_macros.h
@@ -149,7 +149,7 @@ int test_case;
         return;                                                                \
       }                                                                        \
     }                                                                          \
-    printf("PASSED.\n");                                                       \
+    printf("[TC %d] PASSED.\n", casenum);                                                       \
   } while (0)
 
 // Check the results against an in-memory vector of golden values

--- a/sw/riscvTests/isa/rv64uv/vfmv.c
+++ b/sw/riscvTests/isa/rv64uv/vfmv.c
@@ -60,12 +60,41 @@ void TEST_CASE1(void) {
 #endif
 };
 
+void TEST_CASE2(void) {
+  VSET(16, e16, m8);
+  float fscalar_16;
+  //                            -0.9380
+  BOX_HALF_IN_FLOAT(fscalar_16, 0xbb81);
+  VCLEAR(v8);
+  asm volatile("vfmv.s.f v8, %[A]" ::[A] "f"(fscalar_16));
+  VCMP_U16(4, v8, 0xbb81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+  VSET(16, e32, m8);
+  float fscalar_32;
+  //                             -0.96056187
+  BOX_FLOAT_IN_FLOAT(fscalar_32, 0xbf75e762);
+  VCLEAR(v8);
+  asm volatile("vfmv.s.f v8, %[A]" ::[A] "f"(fscalar_32));
+  VCMP_U32(5, v8, 0xbf75e762, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+#if ELEN == 64
+  VSET(16, e64, m8);
+  double dscalar_64;
+  //                               0.9108707261227378
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64, 0x3fed25da5d7296fe);
+  VCLEAR(v8);
+  asm volatile("vfmv.s.f v8, %[A]" ::[A] "f"(dscalar_64));
+  VCMP_U64(6, v8, 0x3fed25da5d7296fe, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+#endif
+};
+
 int main(void) {
   INIT_CHECK();
   enable_vec();
   enable_fp();
 
   TEST_CASE1();
+  TEST_CASE2();
 
   EXIT_CHECK();
 }

--- a/sw/riscvTests/isa/rv64uv/vmv.c
+++ b/sw/riscvTests/isa/rv64uv/vmv.c
@@ -98,6 +98,33 @@ void TEST_CASE3() {
 #endif
 }
 
+void TEST_CASE4 () {
+  // Integer scalar move instructions
+  uint32_t scalar = 0xdeadbeef;
+
+  VSET(16, e8, m8);
+  VLOAD_8(v8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.s.x v8, %[a]" :: [a] "r"(scalar));
+  VCMP_U8(13, v8, 0x000000ef, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e16, m8);
+  VLOAD_16(v8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.s.x v8, %[a]" :: [a] "r"(scalar));
+  VCMP_U16(14, v8, 0x0000beef, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e32, m8);
+  VLOAD_32(v8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.s.x v8, %[a]" :: [a] "r"(scalar));
+  VCMP_U32(15, v8, 0xdeadbeef, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+#if ELEN == 64
+  VSET(16, e64, m8);
+  VLOAD_64(v8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.s.x v8, %[a]" :: [a] "r"(scalar));
+  VCMP_U64(16, v8, 0xffffffffdeadbeef, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+#endif
+}
+
 int main(void) {
   INIT_CHECK();
   enable_vec();
@@ -105,6 +132,7 @@ int main(void) {
   TEST_CASE1();
   TEST_CASE2();
   TEST_CASE3();
+  TEST_CASE4();
 
   EXIT_CHECK();
 }


### PR DESCRIPTION
Some minor fixes to decoding logic for scalar to vector move instructions. For `vmv.s.x` and `vfmv.s.f` variants where only `vd[0]` is changed, don't need to read from the register file.