### PR TITLE
hw: add support to buffer VFU writes during VRF conflicts

### DIFF
--- a/hw/system/spatz_cluster/Makefile
+++ b/hw/system/spatz_cluster/Makefile
@@ -22,6 +22,12 @@ SPATZ_CLUSTER_CFG_DEFINES += -DSNRT_CLUSTER_OFFSET=$(shell python3 -c "import js
 SPATZ_CLUSTER_CFG_DEFINES += -DSNRT_TCDM_SIZE=$(shell python3 -c "import jstyleson; f = open('$(SPATZ_CLUSTER_CFG_PATH)'); print(jstyleson.load(f)['cluster']['tcdm']['size'] * 1024)")
 SPATZ_CLUSTER_CFG_DEFINES += -DSNRT_NFPU_PER_CORE=$(shell python3 -c "import jstyleson; f = open('$(SPATZ_CLUSTER_CFG_PATH)'); print(jstyleson.load(f)['cluster']['n_fpu'])")
 
+# Enable additional uA configurations for the spatz core
+BUF_FPU := $(shell python3 -c "import jstyleson; print(jstyleson.load(open('$(SPATZ_CLUSTER_CFG_PATH)'))['cluster'].get('buf_fpu', 0))")
+ifeq ($(BUF_FPU),1)
+	DEFS += -DBUF_FPU
+endif
+
 # Include Makefrag
 include $(ROOT)/util/Makefrag
 

--- a/hw/system/spatz_cluster/cfg/spatz_cluster.carfield.dram.hjson
+++ b/hw/system/spatz_cluster/cfg/spatz_cluster.carfield.dram.hjson
@@ -32,6 +32,7 @@
         "n_fpu": 4,
         "n_ipu": 1,
         "spatz_fpu": true,
+        "buf_fpu": 0,
         // Timing parameters
         "timing": {
             "lat_comp_fp32": 2,

--- a/hw/system/spatz_cluster/cfg/spatz_cluster.carfield.l2.hjson
+++ b/hw/system/spatz_cluster/cfg/spatz_cluster.carfield.l2.hjson
@@ -32,6 +32,7 @@
         "n_fpu": 4,
         "n_ipu": 1,
         "spatz_fpu": true,
+        "buf_fpu": 0,
         // Timing parameters
         "timing": {
             "lat_comp_fp32": 2,

--- a/hw/system/spatz_cluster/cfg/spatz_cluster.default.dram.hjson
+++ b/hw/system/spatz_cluster/cfg/spatz_cluster.default.dram.hjson
@@ -30,6 +30,7 @@
         "n_fpu": 4,
         "n_ipu": 1,
         "spatz_fpu": true,
+        "buf_fpu": 1,
         // Timing parameters
         "timing": {
             "lat_comp_fp32": 1,

--- a/hw/system/spatz_cluster/cfg/spatz_cluster.mempool.dram.hjson
+++ b/hw/system/spatz_cluster/cfg/spatz_cluster.mempool.dram.hjson
@@ -28,6 +28,7 @@
         n_fpu: 4,
         n_ipu: 1,
         spatz_fpu: true,
+        buf_fpu: 0,
         // Timing parameters
         timing: {
             lat_comp_fp32: 1,


### PR DESCRIPTION
Micro-architectural optimizations to Spatz core to handle Vector Register File conflicts without stalling functional units.

### Additions:
1. **Buffer :** A buffer of size `FpuBufDepth` is added between the `VFU` responses to `VRF` to store data and metadata (`waddr`, `wid`) in case of conflicts with the other execution units such as the `VLSU`.
2. **Dynamic Priority allocation:** If the buffer is not full, `VLSU` is prioritized, while when the buffer occupancy is high, prioritize the `VFU` so as to avoid stalls.

The optimization allows memory-intensive kernels to achieve high `FPU` utilization allowing to prioritze `VLSU` without stalling `VFU`