### PR TITLE
hw: Modify clustergen for dynamic cluster generation

### DIFF
--- a/hw/system/spatz_cluster/src/spatz_cluster_wrapper.sv.tpl
+++ b/hw/system/spatz_cluster/src/spatz_cluster_wrapper.sv.tpl
@@ -255,6 +255,7 @@ module ${cfg['name']}_wrapper
 % if not cfg['tie_ports']:
   input  logic [9:0]                    hart_base_id_i,
   input  logic [AxiAddrWidth-1:0]       cluster_base_addr_i,
+  input  logic [AxiUserWidth-1:0]       axi_core_default_user_i,
 % endif
   output logic                          cluster_probe_o,
 % if cfg['axi_isolate_enable']:

--- a/util/clustergen/cluster.py
+++ b/util/clustergen/cluster.py
@@ -392,7 +392,8 @@ class SnitchClusterTB(Generator):
             self.cfg["dram"]["length"],
             self.cfg["cluster"]["addr_width"],
         )
-        self.cfg["cluster"]["tie_ports"] = True
+        if "tie_ports" not in self.cfg["cluster"]:
+            self.cfg["cluster"]["tie_ports"] = True
         # Store Snitch cluster config in separate variable
         self.cluster = SnitchCluster(cfg["cluster"], pma_cfg)
 


### PR DESCRIPTION
This PR introduces the required changes to set the cluster configuration `tie_ports`.
Before this, the value was hardcoded to `false`, resulting in a hardcoded value for `hart_base_id_i`, `cluster_base_addr_i`, and `axi_core_default_user_i`.

With this change, it is now possible to generate multiple independent Spatz Clusters on a SoC by dynamically setting the aforementioned signals on a higher level. 
 