### PR TITLE
sim: Fix uninitialized clusterwide cc counter

### DIFF
--- a/hw/ip/spatz_cc/src/spatz_cc.sv
+++ b/hw/ip/spatz_cc/src/spatz_cc.sv
@@ -502,6 +502,9 @@ module spatz_cc
     automatic snitch_pkg::fpu_sequencer_trace_port_t extras_fpu_seq_out;
 
     if (rst_ni) begin
+
+      cycle = '0;
+
       extras_snitch = '{
         // State
         source      : snitch_pkg::SrcSnitch,


### PR DESCRIPTION
This PR fixes the tracing scripts / dasm logs of Spatz.

Before the DASM logs had the issue, the current clock cycle for any instruction was set as 'X'.
This issue stems from a unitilized cycle counter variable in the `spatz_cc.sv` file.
The cycle counter was initialized using a synchronous negative reset signal.
If, for any reason (e.g., clock gating), the clock was inactive during the reset assertion, the value would never be initialized.

As the specific cycle count is only used in simulation, this PR mitigates the issue by setting the default value to zero on simulation start.

Further thought could be given to using a synchronized reset signal rather than an asynchronous one.