### PR TITLE
hw: Add SystemRDL for Spatz cluster generation

### DIFF
--- a/hw/system/spatz_cluster/src/spatz_cluster.rdl.tpl
+++ b/hw/system/spatz_cluster/src/spatz_cluster.rdl.tpl
@@ -1,0 +1,44 @@
+## Copyright 2025 ETH Zurich and University of Bologna.
+## Solderpad Hardware License, Version 0.51, see LICENSE for details.
+## SPDX-License-Identifier: SHL-0.51
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+${disclaimer}
+
+<%! 
+import math
+
+def next_power_of_2(n):
+    """Returns the next power of 2 greater than or equal to n."""
+    return 1 if n == 0 else 2**math.ceil(math.log2(n))
+%>
+
+`ifndef __${cfg['name'].upper()}_RDL__
+`define __${cfg['name'].upper()}_RDL__
+
+`include "spatz_cluster_peripheral_reg.rdl"
+
+addrmap ${cfg['name']} {
+
+    default regwidth = ${cfg['dma_data_width']};
+    mem tcdm {
+        mementries = ${hex(int(cfg['tcdm']['size'] * 1024 * 8 / cfg['dma_data_width']))};
+        memwidth = ${cfg['dma_data_width']};
+    };
+
+    mem bootrom {
+        mementries = ${hex(int(4 * 1024 * 8 / cfg['dma_data_width']))};
+        memwidth = ${cfg['dma_data_width']};
+    };
+
+
+
+    external tcdm                 tcdm            ;
+    external bootrom              bootrom         @ ${hex(next_power_of_2(cfg['tcdm']['size']) * 1024)};
+    spatz_cluster_peripheral_reg  peripheral_reg  @ ${hex((next_power_of_2(cfg['tcdm']['size'])+4) * 1024)};
+
+};
+
+`endif // __${cfg['name'].upper()}_RDL__

--- a/hw/system/spatz_cluster/src/spatz_cluster_peripheral/spatz_cluster_peripheral_reg.rdl
+++ b/hw/system/spatz_cluster/src/spatz_cluster_peripheral/spatz_cluster_peripheral_reg.rdl
@@ -1,0 +1,281 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+`ifndef __SPATZ_CLUSTER_PERIPHERAL_REG_RDL__
+`define __SPATZ_CLUSTER_PERIPHERAL_REG_RDL__
+
+addrmap spatz_cluster_peripheral_reg #(
+    longint unsigned NumPerfCounters = 2
+) {
+    default regwidth = 64;
+
+    reg perf_cnt_en {
+        field {
+            name = "enable";
+            desc = "Enable a particular performance counter to start tracking.";
+            hw = r;
+            sw = rw;
+        } enable[0:0] = 1;
+    };
+
+    enum perf_metric {
+        cycle = 0 {
+            desc = "Cycle counter. Counts up as long as the cluster is powered.";
+        };
+        tcdm_accessed = 1 {
+            desc = "Increased whenever the TCDM is accessed. Each individual access is tracked,
+                    so if `n` cores access the TCDM, `n` will be added. Accesses are tracked at the TCDM,
+                    so it doesn't matter whether the cores or for example the SSR hardware accesses
+                    the TCDM. _This is a cluster-global signal._";
+        };
+        tcdm_congested = 2 {
+            desc = "Incremented whenever an access towards the TCDM is made but the arbitration
+                    logic didn't grant the access (due to congestion). It's strictly less than tcdm_accessed.
+                    _This is a cluster-global signal._";
+        };
+        issue_fpu = 3 {
+            desc = "Operations performed in the FPU. Includes both operations initiated by the
+                    sequencer and by the core. When the Xfrep extension is available, this counter is
+                    equivalent to issue_fpu_seq (see description of issue_fpu_seq). If the Xfrep extension
+                    is not supported, then it is equivalent to issue_core_to_fpu. _This is a hart-local signal._";
+        };
+        issue_fpu_seq = 4 {
+            desc = "Incremented whenever the FPU Sequencer issues an FPU instruction.
+                    Might not be available if the hardware doesn't support FREP.
+                    Note that all FP instructions offloaded by the core to the FPU are routed
+                    through the sequencer (although not necessarily buffered) and thus are also counted.
+                    The instructions issued independently by the FPU sequencer could thus be
+                    calculated as issue_fpu_seq_proper = issue_fpu_seq - issue_core_to_fpu.
+                    _This is a hart-local signal._";
+        };
+        issue_core_to_fpu = 5 {
+            desc = "Incremented whenever the core issues an FPU instruction.
+                    _This is a hart-local signal._";
+        };
+        retired_instr = 6 {
+            desc = "Instructions retired by the core, both offloaded and not. Does not
+                    count instructions issued independently by the FPU sequencer.
+                    _This is a hart-local signal._";
+        };
+        retired_load = 7 {
+            desc = "Load instructions retired by the core. _This is a hart-local signal._";
+        };
+        retired_i = 8 {
+            desc = "Base instructions retired by the core. _This is a hart-local signal._";
+        };
+        retired_acc = 9 {
+            desc = "Offloaded instructions retired by the core. _This is a hart-local signal._";
+        };
+        dma_aw_stall = 10 {
+            desc = "Incremented whenever aw_valid = 1 but aw_ready = 0.
+                    _This is a DMA-local signal_";
+        };
+        dma_ar_stall = 11 {
+            desc = "Incremented whenever ar_valid = 1 but ar_ready = 0.
+                    _This is a DMA-local signal_";
+        };
+        dma_r_stall = 12 {
+            desc = "Incremented whenever r_ready = 1 but r_valid = 0.
+                    _This is a DMA-local signal_";
+        };
+        dma_w_stall = 13 {
+            desc = "Incremented whenever w_valid = 1 but w_ready = 0.
+                    _This is a DMA-local signal_";
+        };
+        dma_buf_w_stall = 14 {
+            desc = "Incremented whenever w_ready = 1 but w_valid = 0.
+                    _This is a DMA-local signal_";
+        };
+        dma_buf_r_stall = 15 {
+            desc = "Incremented whenever r_valid = 1 but r_ready = 0.
+                    _This is a DMA-local signal_";
+        };
+        dma_aw_done = 16 {
+            desc = "Incremented whenever AW handshake occurs.
+                    _This is a DMA-local signal_";
+        };
+        dma_aw_bw = 17 {
+            desc = "Whenever AW handshake occurs, the counter is incremented
+                    by the number of bytes transfered for this transaction
+                    _This is a DMA-local signal_";
+        };
+        dma_ar_done = 18 {
+            desc = "Incremented whenever AR handshake occurs.
+                    _This is a DMA-local signal_";
+        };
+        dma_ar_bw = 19 {
+            desc = "Whenever AR handshake occurs, the counter is incremented
+                    by the number of bytes transfered for this transaction
+                    _This is a DMA-local signal_";
+        };
+        dma_r_done = 20 {
+            desc = "Incremented whenever R handshake occurs.
+                    _This is a DMA-local signal_";
+        };
+        dma_r_bw = 21 {
+            desc = "Whenever R handshake occurs, the counter is incremented
+                    by the number of bytes transfered in this cycle
+                    _This is a DMA-local signal_";
+        };
+        dma_w_done = 22 {
+            desc = "Incremented whenvever W handshake occurs.
+                    _This is a DMA-local signal_";
+        };
+        dma_w_bw = 23 {
+            desc = "Whenever W handshake occurs, the counter is incremented
+                    by the number of bytes transfered in this cycle
+                    _This is a DMA-local signal_";
+        };
+        dma_b_done = 24 {
+            desc = "Incremented whenever B handshake occurs.
+                    _This is a DMA-local signal_";
+        };
+        dma_busy = 25 {
+            desc = "Incremented whenever DMA is busy.
+                    _This is a DMA-local signal_";
+        };
+        icache_miss = 26 {
+            desc = "Incremented for instruction cache misses.
+                    _This is a hart-local signal_";
+        };
+        icache_hit = 27 {
+            desc = "Incremented for instruction cache hits.
+                    _This is a hart-local signal_";
+        };
+        icache_prefetch = 28 {
+            desc = "Incremented for instruction cache prefetches.
+                    _This is a hart-local signal_";
+        };
+        icache_double_hit = 29 {
+            desc = "Incremented for instruction cache double hit.
+                    _This is a hart-local signal_";
+        };
+        icache_stall = 30 {
+            desc = "Incremented for instruction cache stalls.
+                    _This is a hart-local signal_";
+        };
+    };
+
+    reg perf_cnt_sel {
+        desc = "Select the metric that is tracked for each performance counter.";
+        field {
+            name = "hart";
+            desc = "Select from which hart in the cluster, starting from `0`,
+                    the event should be counted. For each performance counter
+                    the cores can be selected individually. If a hart greater
+                    than the cluster's total hart size is selected the selection
+                    will wrap and the hart corresponding to `hart_select % total_harts_in_cluster`
+                    will be selected.";
+            hw = rw;
+            sw = rw;
+        } hart[9:0];
+    };
+
+    reg perf_cnt {
+        desc = "Performance counter. Set corresponding perf_cnt_sel register depending on what
+                performance metric and hart you would like to track.";
+        field {
+            desc = "Performance counter";
+            hw = rw;
+            sw = rw;
+            onwrite = wclr;
+        } perf_counter[47:0];
+    };
+
+    reg cl_clint_set {
+        desc = "Set bits in the cluster-local CLINT. Writing a 1 at location i sets the cluster-local interrupt
+                of hart i, where i is relative to the first hart in the cluster, ignoring the cluster base hart ID.";
+        field {
+            desc = "Set cluster-local interrupt of hart i";
+            sw = w;
+            hw = r;
+        } cl_clint_set[31:0];
+    };
+
+    reg cl_clint_clear {
+        desc = "Clear bits in the cluster-local CLINT. Writing a 1 at location i clears the cluster-local interrupt
+                of hart i, where i is relative to the first hart in the cluster, ignoring the cluster base hart ID.";
+        field {
+            desc = "Set cluster-local interrupt of hart i";
+            sw = w;
+            hw = r;
+        } cl_clint_clear[31:0];
+    };
+
+    reg hw_barrier {
+        desc = "Hardware barrier register. Loads to this register will block until all cores have
+                performed the load. At this stage we know that they reached the same point in the control flow,
+                i.e., the cores are synchronized.";
+        field {
+            desc = "Hardware barrier register.";
+            sw = r;
+            hw = rw;
+        } hw_barrier[31:0];
+    };
+
+    reg icache_prefetch_enable {
+        desc = "Controls prefetching of the instruction cache.";
+        field {
+            desc = "Enable instruction prefetching.";
+            hw = r;
+            sw = w;
+        } icache_prefetch_enable[0:0] = 1;
+    };
+
+    reg spatz_status {
+        desc = "Sets the status of the Spatz cluster.";
+        field {
+            desc = "Indicates the cluster is computing a kernel.";
+            sw = w;
+            hw = r;
+        } hw_barrier[0:0] = 0;
+    };
+
+    reg cluster_boot_control {
+        desc = "Controls the cluster boot process";
+        field {
+            desc = "Post-bootstrapping entry point.";
+            sw = rw;
+            hw = r;
+        } boot_cluster[31:0] = 0;
+    };
+
+    reg cluster_eoc_exit {
+        desc = "End of computation and exit status register";
+        field {
+            desc = "Indicates the end of computation and exit status.";
+            sw = rw;
+            hw = r;
+        } eoc_exit[31:0] = 0;
+    };
+
+    // Required for PeakRDL to define the `perf_metric` enum in
+    // the generated RTL file, as this seems not to be done for
+    // for registers defined to be `external`.
+    reg unused {
+        desc = "Unused register added to print enum";
+        field {
+            sw=r; hw=na;
+            encode = perf_metric;
+        } f[4:0] = 0;
+    };
+
+    regfile perf_regs {
+                 perf_cnt_en            perf_cnt_en[NumPerfCounters];
+        external perf_cnt_sel           perf_cnt_sel[NumPerfCounters];
+        external perf_cnt               perf_cnt[NumPerfCounters];
+    };
+
+             perf_regs              perf_regs;
+    external cl_clint_set           cl_clint_set;
+    external cl_clint_clear         cl_clint_clear;
+    external hw_barrier              hw_barrier;
+             icache_prefetch_enable icache_prefetch_enable;
+             spatz_status           spatz_status;
+             cluster_boot_control   cluster_boot_control;
+             cluster_eoc_exit       cluster_eoc_exit;
+             unused                 unused;
+};
+
+`endif // __SPATZ_CLUSTER_PERIPHERAL_REG_RDL__

--- a/util/clustergen.py
+++ b/util/clustergen.py
@@ -54,6 +54,9 @@ def main():
     with open(outdir / "spatz_cluster_wrapper.sv", "w") as f:
         f.write(cluster_tb.render_wrapper())
 
+    with open(outdir / "spatz_cluster.rdl", "w") as f:
+        f.write(cluster_tb.render_rdl())
+
     with open(outdir / "link.ld", "w") as f:
         f.write(cluster_tb.render_linker_script())
 

--- a/util/clustergen/cluster.py
+++ b/util/clustergen/cluster.py
@@ -157,6 +157,7 @@ class SnitchCluster(Generator):
     files = {
         "spatzpkg": "src/spatz_pkg.sv.tpl",
         "wrapper": "src/spatz_cluster_wrapper.sv.tpl",
+        "rdl": "src/spatz_cluster.rdl.tpl",
         "testbench": "tb/testbench.sv.tpl",
     }
 
@@ -183,6 +184,13 @@ class SnitchCluster(Generator):
     def l1_region(self):
         """Return L1 Region as tuple. Base and length."""
         return (self.cfg["cluster_base_addr"], self.cfg["tcdm"]["size"])
+
+    def render_rdl(self):
+        """Render the cluster RDL"""
+        cfg_template = self.templates.get_template(self.files["rdl"])
+        return cfg_template.render_unicode(
+            cfg=self.cfg, to_sv_hex=to_sv_hex, disclaimer=self.DISCLAIMER
+        )
 
     def render_wrapper(self):
         """Render the cluster wrapper"""
@@ -396,6 +404,9 @@ class SnitchClusterTB(Generator):
             self.cfg["cluster"]["tie_ports"] = True
         # Store Snitch cluster config in separate variable
         self.cluster = SnitchCluster(cfg["cluster"], pma_cfg)
+
+    def render_rdl(self):
+        return self.cluster.render_rdl()
 
     def render_wrapper(self):
         return self.cluster.render_wrapper()


### PR DESCRIPTION
This PR introduces the SystemRDL files describing the register map of a Spatz Cluster.
The files are automatically generated using the `clustergen.py` script.

The files are required for SoC level code generation using the FlooNoC tooling.

Note: This only adds the RDL files, but does not yet generate the register files.