### PR TITLE
Index Store Fix

### DIFF
--- a/hw/ip/spatz/src/spatz_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_vlsu.sv
@@ -116,13 +116,17 @@ module spatz_vlsu
     endcase
   end: proc_spatz_req
 
+  // Only do the judgement when we have a valid instruction
+  // This is used to protect false triggeering the counter in some corner cases
   // Do we have a strided memory access
   logic mem_is_strided;
-  assign mem_is_strided = (mem_spatz_req.op == VLSE) || (mem_spatz_req.op == VSSE);
+  assign mem_is_strided = mem_spatz_req_valid &&
+                          ((mem_spatz_req.op == VLSE) || (mem_spatz_req.op == VSSE));
 
   // Do we have an indexed memory access
   logic mem_is_indexed;
-  assign mem_is_indexed = (mem_spatz_req.op == VLXE) || (mem_spatz_req.op == VSXE);
+  assign mem_is_indexed = mem_spatz_req_valid &&
+                          ((mem_spatz_req.op == VLXE) || (mem_spatz_req.op == VSXE));
 
   /////////////
   //  State  //


### PR DESCRIPTION
**Problem/Bug:**
In a back-to-back indexed store case, if the last store of the first index store is not accepted by the memory port immediately, and the next indexed store is not issued in time (e.g., instruction miss). There exists a corner case where the index counter counts an extra one and causes a mismatch when the second index store fires

**Proposed Fix:**
Only raise the `mem_is_indexed` and `mem_is_strided` flags when we have a valid instruction. This will completely stop the counter after sending out the request for the first instruction, therefore preventing the bug.
