### PR TITLE
fix(vfu): extend inter-lane reduction iterations to support 8-lane co…

### DIFF
--- a/hw/ip/spatz/src/spatz_vfu.sv
+++ b/hw/ip/spatz/src/spatz_vfu.sv
@@ -601,7 +601,7 @@ module spatz_vfu
 
           // Written for max 8 FPU / 8 IPUs
           num_inter_lane_iterations_d = (spatz_req.vl << spatz_req.vtype.vsew) <= (ELENB) ? 0:
-                                        (spatz_req.vl << spatz_req.vtype.vsew) <= (2*ELENB) ? 1 : 
+                                        (spatz_req.vl << spatz_req.vtype.vsew) <= (2*ELENB) ? 1 :
                                           (spatz_req.vl << spatz_req.vtype.vsew) <= (4*ELENB) ? 2 : 3;
           num_inter_lane_iterations_d = is_fpu_insn ? (num_inter_lane_iterations_d > $clog2(N_FPU) ? $clog2(N_FPU) : num_inter_lane_iterations_d) :
                                                       (num_inter_lane_iterations_d > $clog2(N_IPU) ? $clog2(N_IPU) : num_inter_lane_iterations_d);

--- a/hw/ip/spatz/src/spatz_vfu.sv
+++ b/hw/ip/spatz/src/spatz_vfu.sv
@@ -599,9 +599,10 @@ module spatz_vfu
         if (!result_valid[0] && (lat_count_q == (FPUlatency + 1))) begin
           reduction_state_d = Reduction_InterLane;
 
-          // Written for max 4 FPU / 4 IPUs
+          // Written for max 8 FPU / 8 IPUs
           num_inter_lane_iterations_d = (spatz_req.vl << spatz_req.vtype.vsew) <= (ELENB) ? 0:
-                                        (spatz_req.vl << spatz_req.vtype.vsew) <= (2*ELENB) ? 1 : 2;
+                                        (spatz_req.vl << spatz_req.vtype.vsew) <= (2*ELENB) ? 1 : 
+                                          (spatz_req.vl << spatz_req.vtype.vsew) <= (4*ELENB) ? 2 : 3;
           num_inter_lane_iterations_d = is_fpu_insn ? (num_inter_lane_iterations_d > $clog2(N_FPU) ? $clog2(N_FPU) : num_inter_lane_iterations_d) :
                                                       (num_inter_lane_iterations_d > $clog2(N_IPU) ? $clog2(N_IPU) : num_inter_lane_iterations_d);
 


### PR DESCRIPTION
Problem
The inter-lane reduction iteration count was capped at 2, which only
supported up to 4-lane configurations (log2(4) = 2 iterations).
In an 8-lane setup, the reduction pipeline was not fully drained,
producing incorrect results.

Fix
Add a fourth case to the iteration count calculation, extending the
maximum to 3 to correctly support 8-lane configurations (log2(8) = 3
iterations). The existing clamp logic via $clog2(N_FPU)/$clog2(N_IPU)
ensures correctness for configurations with fewer lanes.

Testing
Verified reduction operations with 8-lane FPU/IPU configuration
Existing tests for 2-lane and 4-lane configurations remain unaffected