### PR TITLE
(Fix vfu): Changed the condition to exit from IntraLane reduction state

### DIFF
--- a/hw/ip/spatz/src/spatz_vfu.sv
+++ b/hw/ip/spatz/src/spatz_vfu.sv
@@ -596,7 +596,7 @@ module spatz_vfu
 
         // Are we done?
         // Wait until FU latency to ensure the pipelines are drained
-        if (!result_valid[0] && (lat_count_q == (FPUlatency + 1))) begin
+        if (!result_valid[0] && (lat_count_q > (FPUlatency + 1))) begin
           reduction_state_d = Reduction_InterLane;
 
           // Written for max 8 FPU / 8 IPUs


### PR DESCRIPTION
# Spatz IntraLane Reduction Exit Condition Bug

## Executive Summary

**Location:** `spatz_vfu.sv` line 599  
**Symptom:** Deadlock on FP16 reductions with small vectors (N=64), passes with large vectors (N=256)  
**Root Cause:** Exit condition `lat_count == (FPUlatency+1)` uses 1-cycle timeout, but feedback loop has 2-cycle latency (2 hardware registers)  
**Fix:** Change `==` to `>` for 1-cycle safety margin

---

## Configuration & Trigger Condition

**Spatz config:** N_FPU=8, VLEN=512, ELEN=64, PipeRegs[ADDMUL][FP16]=0 → FPUlatency=0

**Bug trigger:** `fill_cnt = 1` 
```systemverilog
fill_cnt = ((vl-1) >> (MAXEW - vsew)) >> $clog2(N_FPU)
```

| Config    | vl  | fill_cnt | Notes                          |
|-----------|-----|----------|--------------------------------|
| N_FPU=8   | 64  | 1        | Tested: triggers bug           |
| N_FPU=8   | 256 | 7        | Tested: passes                 |
| N_FPU=4   | 32  | 1        | Expected: should trigger bug   |

---

## Root Cause: 2-Cycle Feedback Loop

**Register 1:** `reduction_q` (line 308)
```systemverilog
`FF(reduction_q, reduction_d, '0)
```

**Register 2:** `fpu_operand_q` (line 1247-1248)  
```systemverilog
`FFL(fpu_operand1_q, fpu_operand1, int_fpu_in_valid && int_fpu_in_ready, '0)
`FFL(fpu_operand2_q, fpu_operand2, int_fpu_in_valid && int_fpu_in_ready, '0)
```

## Bug Mechanism

**N=64 (fill_cnt=1) timeline:**
```
1. Tree reduction triggered, enters feedback loop (needs 2 cycles)
2. lat_count=1, !result_valid && (1==1) → EXIT (TOO EARLY!)
3. Result arrives (too late), IntraLane already exited → DEADLOCK
```

**N=256 (fill_cnt=7) - passes:**
- Dense pipeline → results arrive continuously
- `lat_count` resets on each result (line 571): `lat_count_d = result_valid[0] ? '0 : lat_count_q + 1;`
- Never reaches timeout while results streaming → exits after completion

---

## Fix

```diff
- if (!result_valid[0] && (lat_count_q == (FPUlatency + 1))) begin
+ if (!result_valid[0] && (lat_count_q > (FPUlatency + 1))) begin
```

**Why `>` works:**
- Timeout changes from `lat_count == 1` to `lat_count > 1` (i.e., `lat_count >= 2`)
- Provides 1 extra cycle for 2-cycle feedback loop
- N=64: Waits 2 cycles → result arrives → exits correctly

--- 
P.S. I already discussed about this fix with Riccardo Giunti, but it is not part of the Organization and I cannot insert him as a reviewer.