### PR TITLE
hw: fix/init vec

### DIFF
--- a/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
@@ -125,11 +125,11 @@ module spatz_doublebw_vlsu
 
   // Do we have a strided memory access
   logic mem_is_strided;
-  assign mem_is_strided = (mem_spatz_req.op == VLSE) || (mem_spatz_req.op == VSSE);
+  assign mem_is_strided = mem_spatz_req_valid && ((mem_spatz_req.op == VLSE) || (mem_spatz_req.op == VSSE));
 
   // Do we have an indexed memory access
   logic mem_is_indexed;
-  assign mem_is_indexed = (mem_spatz_req.op == VLXE) || (mem_spatz_req.op == VSXE);
+  assign mem_is_indexed = mem_spatz_req_valid && ((mem_spatz_req.op == VLXE) || (mem_spatz_req.op == VSXE));
 
   /////////////
   //  State  //
@@ -306,6 +306,9 @@ module spatz_doublebw_vlsu
   logic [NrParallelInstructions-1:0] mem_insn_pending_q, mem_insn_pending_d;
   `FF(mem_insn_pending_q, mem_insn_pending_d, '0)
 
+  // Is there are pending write request to be sent to the memory
+  logic write_pending;
+
   ///////////////////
   //  VRF request  //
   ///////////////////
@@ -381,7 +384,7 @@ module spatz_doublebw_vlsu
     end
 
     // Did an instruction finished its requests?
-    if (&(mem_port_finished_q | (mem_port_finished_d & mem_counter_en))) begin
+    if (&(mem_port_finished_q | (mem_port_finished_d & mem_counter_en)) & !write_pending) begin
       mem_insn_finished_d[mem_spatz_req.id] = 1'b1;
       mem_spatz_req_ready                   = 1'b1;
     end
@@ -833,6 +836,14 @@ module spatz_doublebw_vlsu
   always_comb begin: p_state
     // Maintain state
     state_d = state_q;
+    write_pending = 1'b0;
+
+    for (int intf = 0; intf < NrInterfaces; intf++) begin
+      for (int fu = 0; fu < N_FU; fu++) begin
+        automatic int unsigned port = intf * N_FU + fu;
+        write_pending |= (spatz_mem_req_o[port].write & spatz_mem_req_valid_o[port]);
+      end
+    end
 
     unique case (state_q)
       VLSU_RunningLoad: begin
@@ -844,7 +855,8 @@ module spatz_doublebw_vlsu
       VLSU_RunningStore: begin
         if (commit_insn_valid && commit_insn_q.is_load)
           if (&rob_empty)
-            state_d = VLSU_RunningLoad;
+            if (!write_pending)
+              state_d = VLSU_RunningLoad;
       end
 
       default:;

--- a/hw/ip/spatz/src/spatz_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_vlsu.sv
@@ -291,6 +291,9 @@ module spatz_vlsu
   logic [NrParallelInstructions-1:0] mem_insn_pending_q, mem_insn_pending_d;
   `FF(mem_insn_pending_q, mem_insn_pending_d, '0)
 
+  // Is there are pending write request to be sent to the memory
+  logic write_pending;
+
   ///////////////////
   //  VRF request  //
   ///////////////////
@@ -366,7 +369,7 @@ module spatz_vlsu
     end
 
     // Did an instruction finished its requests?
-    if (&mem_port_finished_q) begin
+    if (&mem_port_finished_q & !write_pending) begin
       mem_insn_finished_d[mem_spatz_req.id] = 1'b1;
       mem_spatz_req_ready                   = 1'b1;
     end
@@ -722,6 +725,11 @@ module spatz_vlsu
   always_comb begin: p_state
     // Maintain state
     state_d = state_q;
+    write_pending = 1'b0;
+
+    for (int port = 0; port < NrMemPorts; port++) begin
+      write_pending |= (spatz_mem_req_o[port].write & spatz_mem_req_valid_o[port]);
+    end
 
     unique case (state_q)
       VLSU_RunningLoad: begin
@@ -733,7 +741,8 @@ module spatz_vlsu
       VLSU_RunningStore: begin
         if (commit_insn_valid && commit_insn_q.is_load)
           if (&rob_empty)
-            state_d = VLSU_RunningLoad;
+            if (!write_pending)
+              state_d = VLSU_RunningLoad;
       end
 
       default:;

--- a/sw/snRuntime/src/start.S.in
+++ b/sw/snRuntime/src/start.S.in
@@ -12,6 +12,14 @@
 _start:
     .globl _start
 
+snrt.crt0.init_vec_registers:
+    li t0, -1
+    vsetvli	zero, t0, e32, m8, ta, ma
+    vmv.v.i v0, 0
+    vmv.v.i v8, 0
+    vmv.v.i v16, 0
+    vmv.v.i v24, 0
+
 snrt.crt0.init_fp_registers:
     # Check if core has FP registers otherwise skip
     csrr    t0, misa


### PR DESCRIPTION
## Fixed

1. **Initialize the vector registers during boot** to please the state machine in VFU that operates by default on 256-bit granularity data `valid_operations` is set to `'1`. For integer operations with vl < VRFWordWidth, atleast `VRFWordWidth` of operations are done. Ideal solution to avoid redundant compute for small vl is to set `valid_operations` correctly.
Without this initialization for e.g. integer division terminates since rest of the `VRFWordWidth` is `XX`
2. **Add conservative switch from store to load instruction.** This is to avoid a scenario, where there are pending stores in the spill register at the output of the VLSU, while the request generation already goes to a load instruction. This causes an issue in handling responses from memory as it is not sure if it is from a pending store or the new load instruction. Safer way is to wait until all pending stores are completed.