### PR TITLE
hw: fix double bw vlsu

### DIFF
--- a/hw/ip/spatz/src/spatz.sv
+++ b/hw/ip/spatz/src/spatz.sv
@@ -494,6 +494,7 @@ module spatz import spatz_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
     // Response
     .vlsu_rsp_valid_o        (vlsu_rsp_valid                                       ),
     .vlsu_rsp_o              (vlsu_rsp                                             ),
+    .vlsu_buf_full_i         (vlsu_buf_full                                        ),
     .vlsu_buf_empty_i        (vlsu_buf_empty                                       ),
     // VRF
     .vrf_wvalid_i            ({vrf_vlsu_wvalid, vrf_wvalid[VLSU_VD_WD0]}           ),

--- a/hw/ip/spatz/src/spatz_controller.sv
+++ b/hw/ip/spatz/src/spatz_controller.sv
@@ -320,12 +320,11 @@ module spatz_controller
       if (sb_wrote_result_i[SB_VFU_VD_WD - SB_VFU_VD_WD])
         vl_cnt_d[sb_id_i[SB_VFU_VD_WD]] += VRFWriteSize;
 
-      if (vl_cnt_q[sb_id_i[SB_VFU_VD_WD]] >= (vl_max_d[sb_id_i[SB_VFU_VD_WD]] * (intID + 1) - VRFWriteSize)) begin
-        done_result_d[intID][sb_id_i[SB_VFU_VD_WD]] = 1'b1;
-      end
-
       wrote_result_narrowing_d[sb_id_i[SB_VFU_VD_WD]] = sb_wrote_result_i[SB_VFU_VD_WD - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VFU_VD_WD]];
       wrote_result_d[intID][sb_id_i[SB_VFU_VD_WD]]    = sb_wrote_result_i[SB_VFU_VD_WD - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VFU_VD_WD]] || wrote_result_narrowing_q[sb_id_i[SB_VFU_VD_WD]]);
+      if (vl_cnt_q[sb_id_i[SB_VFU_VD_WD]] >= (vl_max_d[sb_id_i[SB_VFU_VD_WD]] * (intID + 1) - VRFWriteSize)) begin
+        done_result_d[intID][sb_id_i[SB_VFU_VD_WD]] = wrote_result_d[intID][sb_id_i[SB_VFU_VD_WD]];
+      end
     end
     if (sb_enable_o[SB_VLSU_VD_WD0]) begin
       // Calculate the load-store interface id to use here for chaining
@@ -345,12 +344,11 @@ module spatz_controller
       if (sb_wrote_result_i[SB_VSLDU_VD_WD - SB_VFU_VD_WD])
         vl_cnt_d[sb_id_i[SB_VSLDU_VD_WD]] += VRFWriteSize;
 
-      if (vl_cnt_q[sb_id_i[SB_VSLDU_VD_WD]] >= (vl_max_d[sb_id_i[SB_VSLDU_VD_WD]] * (intID + 1) - VRFWriteSize)) begin
-        done_result_d[intID][sb_id_i[SB_VSLDU_VD_WD]] = 1'b1;
-      end
-
       wrote_result_narrowing_d[sb_id_i[SB_VSLDU_VD_WD]] = sb_wrote_result_i[SB_VSLDU_VD_WD - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VSLDU_VD_WD]];
       wrote_result_d[intID][sb_id_i[SB_VSLDU_VD_WD]]    = sb_wrote_result_i[SB_VSLDU_VD_WD - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VSLDU_VD_WD]] || wrote_result_narrowing_q[sb_id_i[SB_VSLDU_VD_WD]]);
+      if (vl_cnt_q[sb_id_i[SB_VSLDU_VD_WD]] >= (vl_max_d[sb_id_i[SB_VSLDU_VD_WD]] * (intID + 1) - VRFWriteSize)) begin
+        done_result_d[intID][sb_id_i[SB_VSLDU_VD_WD]] = wrote_result_d[intID][sb_id_i[SB_VSLDU_VD_WD]];
+      end
     end
 `else
     // Store the decisions

--- a/hw/ip/spatz/src/spatz_controller.sv
+++ b/hw/ip/spatz/src/spatz_controller.sv
@@ -311,58 +311,39 @@ module spatz_controller
 
 `ifdef DOUBLE_BW
     // Store the decisions
-    if (sb_enable_o[SB_VFU_VD_WD]) begin
-      // Calculate the load-store interface id to use here for chaining
-      automatic logic intID = (vl_cnt_q[sb_id_i[SB_VFU_VD_WD]] < vl_max_d[sb_id_i[SB_VFU_VD_WD]]) ? 0 : 1;
-      automatic int VRFWriteSize = narrow_q[sb_id_i[SB_VFU_VD_WD]] ? VRFWordBWidth >> 1 : VRFWordBWidth;
+    for (int unsigned port = 0; port < NrVregfilePorts; port++) begin
+      automatic int unsigned port_idx = port - SB_VFU_VD_WD;
+      if (sb_enable_o[port]) begin
+        // VFU and VSLDU: intID derived from vl_cnt progress, vl_cnt updated every successful write
+        if (port inside {SB_VFU_VD_WD, SB_VSLDU_VD_WD}) begin
+          automatic logic  intID  = (vl_cnt_q[sb_id_i[port]] < vl_max_d[sb_id_i[port]]) ? 0 : 1;
+          automatic int VRFWriteSize = narrow_q[sb_id_i[port]] ? VRFWordBWidth >> 1 : VRFWordBWidth;
 
-      // Update vl_cnt if actually written into the VRF
-      if (sb_wrote_result_i[SB_VFU_VD_WD - SB_VFU_VD_WD])
-        vl_cnt_d[sb_id_i[SB_VFU_VD_WD]] += VRFWriteSize;
+          // Update vl_cnt if actually written into the VRF
+          if (sb_wrote_result_i[port_idx])
+            vl_cnt_d[sb_id_i[port]] += VRFWriteSize;
 
-      wrote_result_narrowing_d[sb_id_i[SB_VFU_VD_WD]] = sb_wrote_result_i[SB_VFU_VD_WD - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VFU_VD_WD]];
-      wrote_result_d[intID][sb_id_i[SB_VFU_VD_WD]]    = sb_wrote_result_i[SB_VFU_VD_WD - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VFU_VD_WD]] || wrote_result_narrowing_q[sb_id_i[SB_VFU_VD_WD]]);
-      if (vl_cnt_q[sb_id_i[SB_VFU_VD_WD]] >= (vl_max_d[sb_id_i[SB_VFU_VD_WD]] * (intID + 1) - VRFWriteSize)) begin
-        done_result_d[intID][sb_id_i[SB_VFU_VD_WD]] = wrote_result_d[intID][sb_id_i[SB_VFU_VD_WD]];
-      end
-    end
-    if (sb_enable_o[SB_VLSU_VD_WD0]) begin
-      // Calculate the load-store interface id to use here for chaining
-      wrote_result_narrowing_d[sb_id_i[SB_VLSU_VD_WD0]] = sb_wrote_result_i[SB_VLSU_VD_WD0 - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VLSU_VD_WD0]];
-      wrote_result_d[0][sb_id_i[SB_VLSU_VD_WD0]]        = sb_wrote_result_i[SB_VLSU_VD_WD0 - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VLSU_VD_WD0]] || wrote_result_narrowing_q[sb_id_i[SB_VLSU_VD_WD0]]);
-    end
-    if (sb_enable_o[SB_VLSU_VD_WD1]) begin
-      wrote_result_narrowing_d[sb_id_i[SB_VLSU_VD_WD1]] = sb_wrote_result_i[SB_VLSU_VD_WD1 - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VLSU_VD_WD1]];
-      wrote_result_d[1][sb_id_i[SB_VLSU_VD_WD1]]        = sb_wrote_result_i[SB_VLSU_VD_WD1 - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VLSU_VD_WD1]] || wrote_result_narrowing_q[sb_id_i[SB_VLSU_VD_WD1]]);
-    end
-    if (sb_enable_o[SB_VSLDU_VD_WD]) begin
-      // Calculate the load-store interface id to use here for chaining
-      automatic logic intID = (vl_cnt_q[sb_id_i[SB_VSLDU_VD_WD]] < vl_max_d[sb_id_i[SB_VSLDU_VD_WD]]) ? 0 : 1;
-      automatic int VRFWriteSize = narrow_q[sb_id_i[SB_VSLDU_VD_WD]] ? VRFWordBWidth >> 1 : VRFWordBWidth;
-
-      // Update vl_cnt if actually written into the VRF
-      if (sb_wrote_result_i[SB_VSLDU_VD_WD - SB_VFU_VD_WD])
-        vl_cnt_d[sb_id_i[SB_VSLDU_VD_WD]] += VRFWriteSize;
-
-      wrote_result_narrowing_d[sb_id_i[SB_VSLDU_VD_WD]] = sb_wrote_result_i[SB_VSLDU_VD_WD - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VSLDU_VD_WD]];
-      wrote_result_d[intID][sb_id_i[SB_VSLDU_VD_WD]]    = sb_wrote_result_i[SB_VSLDU_VD_WD - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VSLDU_VD_WD]] || wrote_result_narrowing_q[sb_id_i[SB_VSLDU_VD_WD]]);
-      if (vl_cnt_q[sb_id_i[SB_VSLDU_VD_WD]] >= (vl_max_d[sb_id_i[SB_VSLDU_VD_WD]] * (intID + 1) - VRFWriteSize)) begin
-        done_result_d[intID][sb_id_i[SB_VSLDU_VD_WD]] = wrote_result_d[intID][sb_id_i[SB_VSLDU_VD_WD]];
+          wrote_result_narrowing_d[sb_id_i[port]] = sb_wrote_result_i[port_idx] ^ narrow_wide_q[sb_id_i[port]];
+          wrote_result_d[intID][sb_id_i[port]]    = sb_wrote_result_i[port_idx] && (!narrow_wide_q[sb_id_i[port]] || wrote_result_narrowing_q[sb_id_i[port]]);
+          if (vl_cnt_q[sb_id_i[port]] >= (vl_max_d[sb_id_i[port]] * (intID + 1) - VRFWriteSize))
+            done_result_d[intID][sb_id_i[port]] = wrote_result_d[intID][sb_id_i[port]];
+        end
+        // VLSU: intID is fixed per interface (0 for WD0, 1 for WD1)
+        if (port inside {SB_VLSU_VD_WD0, SB_VLSU_VD_WD1}) begin
+          automatic int unsigned intID  = port - SB_VLSU_VD_WD0;
+          wrote_result_narrowing_d[sb_id_i[port]] = sb_wrote_result_i[port_idx] ^ narrow_wide_q[sb_id_i[port]];
+          wrote_result_d[intID][sb_id_i[port]]    = sb_wrote_result_i[port_idx] && (!narrow_wide_q[sb_id_i[port]] || wrote_result_narrowing_q[sb_id_i[port]]);
+        end
       end
     end
 `else
-    // Store the decisions
-    if (sb_enable_o[SB_VFU_VD_WD]) begin
-      wrote_result_narrowing_d[sb_id_i[SB_VFU_VD_WD]] = sb_wrote_result_i[SB_VFU_VD_WD - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VFU_VD_WD]];
-      wrote_result_d[sb_id_i[SB_VFU_VD_WD]]           = sb_wrote_result_i[SB_VFU_VD_WD - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VFU_VD_WD]] || wrote_result_narrowing_q[sb_id_i[SB_VFU_VD_WD]]);
-    end
-    if (sb_enable_o[SB_VLSU_VD_WD]) begin
-      wrote_result_narrowing_d[sb_id_i[SB_VLSU_VD_WD]] = sb_wrote_result_i[SB_VLSU_VD_WD - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VLSU_VD_WD]];
-      wrote_result_d[sb_id_i[SB_VLSU_VD_WD]]           = sb_wrote_result_i[SB_VLSU_VD_WD - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VLSU_VD_WD]] || wrote_result_narrowing_q[sb_id_i[SB_VLSU_VD_WD]]);
-    end
-    if (sb_enable_o[SB_VSLDU_VD_WD]) begin
-      wrote_result_narrowing_d[sb_id_i[SB_VSLDU_VD_WD]] = sb_wrote_result_i[SB_VSLDU_VD_WD - SB_VFU_VD_WD] ^ narrow_wide_q[sb_id_i[SB_VSLDU_VD_WD]];
-      wrote_result_d[sb_id_i[SB_VSLDU_VD_WD]]           = sb_wrote_result_i[SB_VSLDU_VD_WD - SB_VFU_VD_WD] && (!narrow_wide_q[sb_id_i[SB_VSLDU_VD_WD]] || wrote_result_narrowing_q[sb_id_i[SB_VSLDU_VD_WD]]);
+    // Store the decisions for all write-destination ports: VFU, VLSU, VSLDU
+    for (int unsigned port = 0; port < NrVregfilePorts; port++) begin
+      if (sb_enable_o[port] && (port inside {SB_VFU_VD_WD, SB_VLSU_VD_WD, SB_VSLDU_VD_WD})) begin
+        automatic int unsigned port_idx = port - SB_VFU_VD_WD;
+        wrote_result_narrowing_d[sb_id_i[port]] = sb_wrote_result_i[port_idx] ^ narrow_wide_q[sb_id_i[port]];
+        wrote_result_d[sb_id_i[port]]           = sb_wrote_result_i[port_idx] && (!narrow_wide_q[sb_id_i[port]] || wrote_result_narrowing_q[sb_id_i[port]]);
+      end
     end
 `endif
 

--- a/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
@@ -87,6 +87,8 @@ module spatz_doublebw_vlsu
   logic       mem_spatz_req_valid;
   logic       mem_spatz_req_ready;
 
+  logic spatz_req_ready;
+
   spill_register #(
     .T(spatz_req_t)
   ) i_operation_queue (
@@ -94,7 +96,7 @@ module spatz_doublebw_vlsu
     .rst_ni (rst_ni                                         ),
     .data_i (spatz_req_d                                    ),
     .valid_i(spatz_req_valid_i && spatz_req_i.ex_unit == LSU),
-    .ready_o(spatz_req_ready_o                              ),
+    .ready_o(spatz_req_ready                                ),
     .data_o (mem_spatz_req                                  ),
     .valid_o(mem_spatz_req_valid                            ),
     .ready_i(mem_spatz_req_ready                            )
@@ -337,7 +339,7 @@ module spatz_doublebw_vlsu
   logic             commit_insn_push;
   commit_metadata_t commit_insn_q;
   logic             commit_insn_pop;
-  logic             commit_insn_empty;
+  logic             commit_insn_empty, commit_insn_full;
   logic             commit_insn_valid;
 
   fifo_v3 #(
@@ -351,12 +353,14 @@ module spatz_doublebw_vlsu
     .testmode_i(1'b0             ),
     .data_i    (commit_insn_d    ),
     .push_i    (commit_insn_push ),
-    .full_o    (/* Unused */     ),
+    .full_o    (commit_insn_full ),
     .data_o    (commit_insn_q    ),
     .empty_o   (commit_insn_empty),
     .pop_i     (commit_insn_pop  ),
     .usage_o   (/* Unused */     )
   );
+
+  assign spatz_req_ready_o = spatz_req_ready & !commit_insn_full;
 
   assign commit_insn_valid = !commit_insn_empty;
   assign commit_insn_d     = '{
@@ -383,7 +387,7 @@ module spatz_doublebw_vlsu
     commit_insn_push = 1'b0;
 
     // Did we start a new instruction?
-    if (mem_spatz_req_valid && !mem_insn_pending_q[mem_spatz_req.id]) begin
+    if (mem_spatz_req_valid && !mem_insn_pending_q[mem_spatz_req.id] && !commit_insn_full) begin
       mem_insn_pending_d[mem_spatz_req.id] = 1'b1;
       commit_insn_push                     = 1'b1;
     end

--- a/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
@@ -490,18 +490,19 @@ module spatz_doublebw_vlsu
             default: offset = $signed(vrf_rdata_i[intf][1][8 * word_index +: 32]);
           endcase
         end else begin
-          offset = ({mem_counter_q[intf][fu][$bits(vlen_t)-1:MAXEW] << $clog2(N_FU), mem_counter_q[intf][fu][int'(MAXEW)-1:0]} + (fu << MAXEW)) * stride;
+          offset = ({mem_counter_q[intf][fu][$bits(vlen_t)-1:MAXEW] << $clog2(N_FU), mem_counter_q[intf][fu][int'(MAXEW)-1:0]} + (fu << MAXEW));
         end
 
         // The second interface starts from half of the vector to straighten the write-back VRF access pattern
         // To ensure that the 2 interfaces do not also conflict at the TCDM, there is HW scrambling of addresses to TCDM
         // such that they access different superbanks.
-        if (!mem_is_indexed && !mem_is_strided && intf == 1) begin
+        if (!mem_is_indexed && intf == 1) begin
           // Align the vector length with SpatzMemBytes bytes
           offset += ((mem_spatz_req.vl +  (SpatzMemBytes / 2)) >> $clog2(SpatzMemBytes) << $clog2(SpatzMemBytes)) / 2;
         end
+        offset *= stride;
 
-        addr                      = mem_spatz_req.rs1 + offset;
+        addr                          = mem_spatz_req.rs1 + offset;
         mem_req_addr[intf][fu]        = (addr >> MAXEW) << MAXEW;
         mem_req_addr_offset[intf][fu] = addr[int'(MAXEW)-1:0];
 

--- a/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
@@ -142,6 +142,10 @@ module spatz_doublebw_vlsu
   state_t state_d, state_q;
   `FF(state_q, state_d, VLSU_RunningLoad)
 
+  // Memory requests
+  spatz_mem_req_t [NrInterfaces-1:0] [N_FU-1:0] spatz_mem_req;
+  logic           [NrInterfaces-1:0] [N_FU-1:0] spatz_mem_req_valid;
+  logic           [NrInterfaces-1:0] [N_FU-1:0] spatz_mem_req_ready;
 
   id_t [NrInterfaces-1:0] [N_FU-1:0] store_count_q;
   id_t [NrInterfaces-1:0] [N_FU-1:0] store_count_d;
@@ -160,7 +164,7 @@ module spatz_doublebw_vlsu
       for (int fu = 0; fu < N_FU; fu++) begin
         automatic int unsigned port = intf * N_FU + fu;
 
-        if (spatz_mem_req_o[port].write && spatz_mem_req_valid_o[port] && spatz_mem_req_ready_i[port])
+        if (spatz_mem_req[intf][fu].write && spatz_mem_req_valid[intf][fu] && spatz_mem_req_ready[intf][fu])
           // Did we send a store?
           store_count_d[intf][fu]++;
 
@@ -540,11 +544,6 @@ module spatz_doublebw_vlsu
   // Did we finish an instruction?
   logic vlsu_finished_req;
 
-  // Memory requests
-  spatz_mem_req_t [NrInterfaces-1:0] [N_FU-1:0] spatz_mem_req;
-  logic           [NrInterfaces-1:0] [N_FU-1:0] spatz_mem_req_valid;
-  logic           [NrInterfaces-1:0] [N_FU-1:0] spatz_mem_req_ready;
-
   always_comb begin: control_proc
     // Maintain state
     busy_d = busy_q;
@@ -849,7 +848,7 @@ module spatz_doublebw_vlsu
     for (int intf = 0; intf < NrInterfaces; intf++) begin
       for (int fu = 0; fu < N_FU; fu++) begin
         automatic int unsigned port = intf * N_FU + fu;
-        write_pending |= (spatz_mem_req_o[port].write & spatz_mem_req_valid_o[port]);
+        write_pending |= (store_count_d[intf][fu] != '0);
       end
     end
 

--- a/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_doublebw_vlsu.sv
@@ -34,6 +34,7 @@ module spatz_doublebw_vlsu
     output logic                            vlsu_rsp_valid_o,
     output vlsu_rsp_t                       vlsu_rsp_o,
     input  logic                            vlsu_buf_empty_i,
+    input  logic                            vlsu_buf_full_i,
     // Interface with the VRF
     output vrf_addr_t      [NrInterfaces-1:0] vrf_waddr_o,
     output vrf_data_t      [NrInterfaces-1:0] vrf_wdata_o,
@@ -650,16 +651,16 @@ module spatz_doublebw_vlsu
 
     vlsu_rsp_t rsp;
     logic rsp_valid;
+    vlen_t commit_vl;
   } vrf_req_t;
 
   vrf_req_t [NrInterfaces-1:0] vrf_req_d, vrf_req_q;
   logic     [NrInterfaces-1:0] vrf_req_valid_d, vrf_req_ready_d;
   logic     [NrInterfaces-1:0] vrf_req_valid_q, vrf_req_ready_q;
-  logic     [NrInterfaces-1:0] vrf_commit_pending_d, vrf_commit_pending_q, vrf_valid_rsp;
+  logic     [NrInterfaces-1:0] vrf_commit_waiting_d, vrf_commit_waiting_q, vrf_valid_rsp;
   logic     [NrInterfaces-1:0] vrf_commit_intf_valid, vrf_commit_intf_valid_q;
 
-  logic vrf_commit_bypass_d, vrf_commit_bypass_q;
-  `FF(vrf_commit_bypass_q, vrf_commit_bypass_d, 1'b0)
+  logic vrf_commit_bypass;
 
   for (genvar intf = 0; intf < NrInterfaces; intf++) begin : gen_vrf_req_register_intf
     spill_register #(
@@ -678,15 +679,22 @@ module spatz_doublebw_vlsu
     assign vrf_waddr_o[intf]     = vrf_req_q[intf].waddr;
     assign vrf_wdata_o[intf]     = vrf_req_q[intf].wdata;
     assign vrf_wbe_o[intf]       = vrf_req_q[intf].wbe;
-    // If VLSU0 is the last interface to finish, make sure there is nothing in the VLSU1 buffer to VRF to avoid
-    // clearing the instruction from controller before all commits to VRF are done for the instruction
-    // If VLSU1 is last to finish, since it goes through the buffer, we know it will never go ahead of VLSU0
-    assign vrf_we_o[intf]        = vrf_req_valid_q[intf] & ~vrf_commit_pending_q[intf] & ((intf == 0) && vrf_valid_rsp[0] && !vrf_valid_rsp[1] ? vlsu_buf_empty_i : 1'b1);
+    // Ensure simpler synchronization for commits from both interfaces
+    // Writeback:
+    // For interface 1, check if interface 0 commit can go through
+    // For interface 0, check if interface1 buffer is not full
+    // Retiring:
+    // If Interface 1, is resp interface (usually the default)
+    // If Interface 0, is resp interface (if interface 0 has more vector elements), then ensure interface 1 has nothing in buffer
+    // to avoid retiring before interface 1 commits to the VRF
+    assign vrf_we_o[intf]        = ((&vrf_req_valid_q) | ((intf==0) ? vrf_req_valid_q[0] & (vrf_commit_bypass | vrf_commit_waiting_q[1]) & vlsu_buf_empty_i : 1'b0)) &
+                                   ((intf==1) ? (vrf_wvalid_i[0] & (vrf_req_q[1].rsp.id == vrf_req_q[0].rsp.id)) : 1'b1) &
+                                   !vlsu_buf_full_i;
     assign vrf_id_o[intf]        = {vrf_req_q[intf].rsp.id, mem_spatz_req.id, commit_insn_q.id};
     assign vrf_req_ready_q[intf] = vrf_wvalid_i[intf];
 
     `FF(vrf_commit_intf_valid_q[intf], vrf_commit_intf_valid[intf], 1'b0)
-    `FF(vrf_commit_pending_q[intf], vrf_commit_pending_d[intf], 1'b0)
+    `FF(vrf_commit_waiting_q[intf], vrf_commit_waiting_d[intf], 1'b0)
   end
 
   //////////////////////////////////////
@@ -696,22 +704,21 @@ module spatz_doublebw_vlsu
   always_comb begin
     vrf_valid_rsp = '0;
     vrf_commit_intf_valid = vrf_commit_intf_valid_q;
-    vrf_commit_pending_d = vrf_commit_pending_q;
-    vrf_commit_bypass_d = vrf_commit_bypass_q;
+    vrf_commit_waiting_d = vrf_commit_waiting_q;
 
     // To track if the second interface is committing or not for small vector lengths
-    vrf_commit_bypass_d = commit_insn_valid ? ((commit_insn_q.vl <= ( SpatzMemBytes / 2)) ? 1'b1 : 1'b0) : vrf_commit_bypass_q;
+    vrf_commit_bypass = vrf_req_valid_q[0] ? ((vrf_req_q[0].commit_vl <= ( SpatzMemBytes / 2)) ? 1'b1 : 1'b0) : 1'b0;
 
     for (int intf = 0; intf < NrInterfaces; intf++) begin
       // We have a final resp to write to VRF
       vrf_valid_rsp[intf] = (vrf_req_valid_q[intf] & vrf_req_q[intf].rsp_valid);
 
       // Track if the final resp has already been written to the VRF
-      vrf_commit_intf_valid[intf] = ((vrf_valid_rsp[intf] & vrf_wvalid_i[intf]) | vrf_commit_pending_q[intf]) | (intf == 1 ? vrf_commit_bypass_q : 1'b0);
+      vrf_commit_intf_valid[intf] = ((vrf_valid_rsp[intf] & vrf_wvalid_i[intf]) | vrf_commit_waiting_q[intf]) | (intf == 1 ? vrf_commit_bypass : 1'b0);
 
       // To track if the last packet has already been committed for the interface, but a response cannot be sent to the controller
       // since waiting for the other interface to finish
-      vrf_commit_pending_d[intf] = vrf_commit_intf_valid[intf] ? (vlsu_rsp_valid_o ? 1'b0 : 1'b1) : 1'b0;
+      vrf_commit_waiting_d[intf] = vrf_commit_intf_valid[intf] ? (vlsu_rsp_valid_o ? 1'b0 : 1'b1) : 1'b0;
     end
   end
 
@@ -724,7 +731,7 @@ module spatz_doublebw_vlsu
 
   // Check if interface 1 is the interface trying to commit, if so take resp information from interface 1
   // If both interfaces in sync, interface 1 is given priority
-  assign resp_intf = vrf_commit_intf_valid_q [1] == 1'b0 ? 1'b1 : 1'b0;
+  assign resp_intf = ((vrf_commit_intf_valid [1] == 1'b1) & !vrf_commit_bypass) ? 1'b1 : 1'b0;
 
   // Check is both interfaces has reached to a completion and if the last write to the VRF is also done
   // Assign the instruction id from the interface that completes the last
@@ -923,6 +930,7 @@ module spatz_doublebw_vlsu
       vrf_req_d[intf].rsp.id    = commit_insn_q.id;
       vrf_req_d[intf].rsp.intf_id = intf;
       vrf_req_d[intf].rsp_valid = commit_insn_valid && &commit_finished_d[intf] && mem_insn_finished_d[commit_insn_q.id];
+      vrf_req_d[intf].commit_vl = commit_insn_q.vl;
 
       // Request indexes
       vrf_re_o[intf][1] = mem_is_indexed;

--- a/hw/ip/spatz/src/spatz_vlsu.sv
+++ b/hw/ip/spatz/src/spatz_vlsu.sv
@@ -79,6 +79,8 @@ module spatz_vlsu
   logic       mem_spatz_req_valid;
   logic       mem_spatz_req_ready;
 
+  logic spatz_req_ready;
+
   spill_register #(
     .T(spatz_req_t)
   ) i_operation_queue (
@@ -86,7 +88,7 @@ module spatz_vlsu
     .rst_ni (rst_ni                                         ),
     .data_i (spatz_req_d                                    ),
     .valid_i(spatz_req_valid_i && spatz_req_i.ex_unit == LSU),
-    .ready_o(spatz_req_ready_o                              ),
+    .ready_o(spatz_req_ready                                ),
     .data_o (mem_spatz_req                                  ),
     .valid_o(mem_spatz_req_valid                            ),
     .ready_i(mem_spatz_req_ready                            )
@@ -317,7 +319,7 @@ module spatz_vlsu
   logic             commit_insn_push;
   commit_metadata_t commit_insn_q;
   logic             commit_insn_pop;
-  logic             commit_insn_empty;
+  logic             commit_insn_empty, commit_insn_full;
   logic             commit_insn_valid;
 
   fifo_v3 #(
@@ -331,7 +333,7 @@ module spatz_vlsu
     .testmode_i(1'b0             ),
     .data_i    (commit_insn_d    ),
     .push_i    (commit_insn_push ),
-    .full_o    (/* Unused */     ),
+    .full_o    (commit_insn_full ),
     .data_o    (commit_insn_q    ),
     .empty_o   (commit_insn_empty),
     .pop_i     (commit_insn_pop  ),
@@ -351,6 +353,8 @@ module spatz_vlsu
       is_indexed: mem_is_indexed
   };
 
+  assign spatz_req_ready_o = spatz_req_ready & !commit_insn_full;
+
   always_comb begin: queue_control
     // Maintain state
     mem_insn_finished_d = mem_insn_finished_q;
@@ -363,7 +367,7 @@ module spatz_vlsu
     commit_insn_push = 1'b0;
 
     // Did we start a new instruction?
-    if (mem_spatz_req_valid && !mem_insn_pending_q[mem_spatz_req.id]) begin
+    if (mem_spatz_req_valid && !mem_insn_pending_q[mem_spatz_req.id] && !commit_insn_full) begin
       mem_insn_pending_d[mem_spatz_req.id] = 1'b1;
       commit_insn_push                     = 1'b1;
     end

--- a/hw/system/spatz_cluster/Makefile
+++ b/hw/system/spatz_cluster/Makefile
@@ -229,7 +229,7 @@ lint: generate lint/tmp/files lint/sdc/func.sdc lint/script/lint.tcl
 
 lint/tmp/files: ${BENDER}
 	mkdir -p lint/tmp
-	${BENDER} script verilator -t rtl -t spatz > lint/tmp/files
+	${BENDER} script verilator -t rtl -t spatz ${DEFS} > lint/tmp/files
 
 ######
 # SW #

--- a/sw/riscvTests/CMakeLists.txt
+++ b/sw/riscvTests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_snitch_test(vadd  isa/rv64uv/vadd.c)
 add_snitch_test(vsub  isa/rv64uv/vsub.c)
 add_snitch_test(vrsub isa/rv64uv/vrsub.c)
 
+add_snitch_test(vls    isa/rv64uv/vls.c)
 add_snitch_test(vloxei isa/rv64uv/vloxei.c)
 add_snitch_test(vsuxei isa/rv64uv/vsuxei.c)
 

--- a/sw/riscvTests/isa/rv64uv/vls.c
+++ b/sw/riscvTests/isa/rv64uv/vls.c
@@ -1,0 +1,392 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+//         Navaneeth Kunhi Purayil <nkunhi@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+int8_t mask[1] = {0xAA};
+
+// Positive-stride tests
+void TEST_CASE1(void) {
+  VSET(4, e8, m1);
+  volatile uint8_t INP1[] = {0x9f, 0xe4, 0x19, 0x20, 0x8f, 0x2e, 0x05, 0xe0,
+                             0xf9, 0xaa, 0x71, 0xf0, 0xc3, 0x94, 0xbb, 0xd3};
+  uint64_t stride = 3;
+  asm volatile("vlse8.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U8(1, v1, 0x9f, 0x20, 0x05, 0xaa);
+}
+
+void TEST_CASE2(void) {
+  VSET(4, e16, m1);
+  volatile uint16_t INP1[] = {0x9fe4, 0x1920, 0x8f2e, 0x05e0,
+                              0xf9aa, 0x71f0, 0xc394, 0xbbd3};
+  uint64_t stride = 4;
+  asm volatile("vlse16.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U16(2, v1, 0x9fe4, 0x8f2e, 0xf9aa, 0xc394);
+}
+
+void TEST_CASE3(void) {
+  VSET(4, e32, m1);
+  volatile uint32_t INP1[] = {0x9fe41920, 0x8f2e05e0, 0xf9aa71f0, 0xc394bbd3,
+                              0xa11a9384, 0xa7163840, 0x99991348, 0xa9f38cd1};
+  uint64_t stride = 8;
+  asm volatile("vlse32.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U32(3, v1, 0x9fe41920, 0xf9aa71f0, 0xa11a9384, 0x99991348);
+}
+
+void TEST_CASE4(void) {
+#if ELEN == 64
+  VSET(4, e64, m1);
+  volatile uint64_t INP1[] = {0x9fe419208f2e05e0, 0xf9aa71f0c394bbd3,
+                              0xa11a9384a7163840, 0x99991348a9f38cd1};
+  uint64_t stride = 8;
+  asm volatile("vlse64.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U64(4, v1, 0x9fe419208f2e05e0, 0xf9aa71f0c394bbd3, 0xa11a9384a7163840,
+           0x99991348a9f38cd1);
+#endif
+}
+
+void TEST_CASE5(void) {
+  VSET(8, e8, m1);
+  volatile uint8_t INP1[] = {0x9f, 0xe4, 0x19, 0x20, 0x8f, 0x2e, 0x05, 0xe0,
+                             0xf9, 0xaa, 0x71, 0xf0, 0xc3, 0x94, 0xbb, 0xd3,
+                             0x9f, 0xe4, 0x19, 0x20, 0x8f, 0x2e, 0x05, 0xe0,
+                             0xf9, 0xaa, 0x71, 0xf0, 0xc3, 0x94, 0xbb, 0xd3};
+  uint64_t stride = 3;
+  asm volatile("vlse8.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U8(5, v1, 0x9f, 0x20, 0x05, 0xaa, 0xc3, 0xd3, 0x19, 0x2e);
+}
+
+void TEST_CASE6(void) {
+  VSET(8, e16, m1);
+  volatile uint16_t INP1[] = {0x7a3d, 0xc124, 0x5ef9, 0x80b7,
+                              0x2dd0, 0x91e2, 0x4b6c, 0xf813,
+                              0x36a5, 0xd47f, 0x0c98, 0xb2e1,
+                              0x695a, 0xe70d, 0x13c4, 0xacf6};
+  uint64_t stride = 4;
+  asm volatile("vlse16.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U16(6, v1, 0x7a3d, 0x5ef9, 0x2dd0, 0x4b6c, 0x36a5, 0x0c98, 0x695a, 0x13c4);
+}
+
+void TEST_CASE7(void) {
+  VSET(8, e32, m1);
+  volatile uint32_t INP1[] = {0x8f31c4a7, 0x15be9072, 0xd26a4f1d, 0x7043e8b9,
+                              0x2cb59760, 0xfa1843de, 0x61d90a85, 0x9374bc2f,
+                              0x4ea12d68, 0xb8f06c13, 0x07cd52f1, 0xe39b847a,
+                              0x596ef320, 0xacc1459d, 0x3b7288e4, 0xc6d0175b};
+  uint64_t stride = 8;
+  asm volatile("vlse32.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U32(7, v1, 0x8f31c4a7, 0xd26a4f1d, 0x2cb59760, 0x61d90a85, 0x4ea12d68, 0x07cd52f1, 0x596ef320, 0x3b7288e4);
+}
+
+void TEST_CASE8(void) {
+#if ELEN == 64
+  VSET(8, e64, m2);
+  volatile uint64_t INP1[] = {0x7c31e9a5d0428f16, 0xb57a0c6e913df248,
+                              0x18d4fa709c25be63, 0xe2b36d1487f950ac,
+                              0x49cf825ab31e670d, 0x96a1780fe4d2cb35,
+                              0x2df05c93a86b1741, 0xc8e49b26751adf90};
+  uint64_t stride = 8;
+  asm volatile("vlse64.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U64(8, v1, 0x7c31e9a5d0428f16, 0xb57a0c6e913df248, 0x18d4fa709c25be63,
+           0xe2b36d1487f950ac, 0x49cf825ab31e670d, 0x96a1780fe4d2cb35,
+           0x2df05c93a86b1741, 0xc8e49b26751adf90);
+#endif
+}
+
+// Zero-stride tests
+// The implementation must perform all the memory accesses
+void TEST_CASE9(void) {
+  VSET(16, e8, m1);
+  volatile uint8_t INP1[] = {0x9f};
+  uint64_t stride = 0;
+  asm volatile("vlse8.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U8(9, v1, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f,
+          0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f);
+}
+
+// The implementation can also perform fewer accesses
+void TEST_CASE10(void) {
+  VSET(16, e8, m1);
+  volatile uint8_t INP1[] = {0x9f};
+  asm volatile("vlse8.v v1, (%0), x0" ::"r"(INP1));
+  VCMP_U8(10, v1, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f,
+          0x9f, 0x9f, 0x9f, 0x9f, 0x9f, 0x9f);
+}
+
+// Different LMUL
+void TEST_CASE11(void) {
+#if ELEN == 64
+  VSET(8, e64, m2);
+  volatile uint64_t INP1[] = {0x9fa831c7a11a9384};
+  asm volatile("vlse64.v v2, (%0), x0" ::"r"(INP1));
+  VCMP_U64(11, v2, 0x9fa831c7a11a9384, 0x9fa831c7a11a9384, 0x9fa831c7a11a9384,
+           0x9fa831c7a11a9384, 0x9fa831c7a11a9384, 0x9fa831c7a11a9384,
+           0x9fa831c7a11a9384, 0x9fa831c7a11a9384);
+#endif
+}
+
+// Others
+// Negative-stride test
+void TEST_CASE12(void) {
+  VSET(4, e16, m1);
+  volatile uint16_t INP1[] = {0x9fe4, 0x1920, 0x8f2e, 0x05e0,
+                              0xf9aa, 0x71f0, 0xc394, 0xbbd3};
+  uint64_t stride = -4;
+  asm volatile("vlse16.v v1, (%0), %1" ::"r"(&INP1[7]), "r"(stride));
+  VCMP_U16(12, v1, 0xbbd3, 0x71f0, 0x05e0, 0x1920);
+}
+
+// Stride > SpatzMemBytes
+void TEST_CASE13(void) {
+#if ELEN == 64
+  VSET(2, e64, m1);
+  volatile uint64_t INP1[] = {0x99991348a9f38cd1, 0x9fa831c7a11a9384,
+                              0x9fa831c7a11a9384, 0x9fa831c7a11a9384,
+                              0x9fa831c7a11a9384, 0x01015ac1309bb678};
+  uint64_t stride = 40;
+  asm volatile("vlse64.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U64(13, v1, 0x99991348a9f38cd1, 0x01015ac1309bb678);
+#endif
+}
+
+// Fill Spatz register
+void TEST_CASE14(void) {
+#if ELEN == 64
+  VSET(8, e64, m2);
+  volatile uint64_t INP1[] = {
+      0x9fe419208f2e05e0, 0xf9aa71f0c394bbd3, 0xa11a9384a7163840,
+      0x99991348a9f38cd1, 0x9fa831c7a11a9384, 0x3819759853987548,
+      0x1893179501093489, 0x81937598aa819388, 0x1874754791888188,
+      0x3eeeeeeee33111ae, 0x9013930148815808, 0xab8b914891484891,
+      0x9031850931584902, 0x3189759837598759, 0x8319599991911111,
+      0x8913984898951989};
+  uint64_t stride = 16;
+  asm volatile("vlse64.v v1, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U64(14, v1, 0x9fe419208f2e05e0, 0xa11a9384a7163840, 0x9fa831c7a11a9384,
+           0x1893179501093489, 0x1874754791888188, 0x9013930148815808,
+           0x9031850931584902, 0x8319599991911111);
+#endif
+}
+
+// Masked stride loads
+void TEST_CASE15(void) {
+  VSET(4, e8, m1);
+  volatile uint8_t INP1[] = {0x9f, 0xe4, 0x19, 0x20, 0x8f, 0x2e, 0x05, 0xe0,
+                             0xf9, 0xaa, 0x71, 0xf0, 0xc3, 0x94, 0xbb, 0xd3};
+  uint64_t stride = 3;
+  VLOAD_8(v0, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vlse8.v v1, (%0), %1, v0.t" ::"r"(INP1), "r"(stride));
+  VCMP_U8(15, v1, 0x00, 0x20, 0x00, 0xaa);
+}
+
+void TEST_CASE16(void) {
+  VSET(4, e16, m1);
+  volatile uint16_t INP1[] = {0x9fe4, 0x1920, 0x8f2e, 0x05e0,
+                              0xf9aa, 0x71f0, 0xc394, 0xbbd3};
+  uint64_t stride = 4;
+  VLOAD_8(v0, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vlse16.v v1, (%0), %1, v0.t" ::"r"(INP1), "r"(stride));
+  VCMP_U16(16, v1, 0, 0x8f2e, 0, 0xc394);
+}
+
+void TEST_CASE17(void) {
+  VSET(4, e32, m1);
+  volatile uint32_t INP1[] = {0x9fe41920, 0x8f2e05e0, 0xf9aa71f0, 0xc394bbd3,
+                              0xa11a9384, 0xa7163840, 0x99991348, 0xa9f38cd1};
+  uint64_t stride = 8;
+  VLOAD_8(v0, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vlse32.v v1, (%0), %1, v0.t" ::"r"(INP1), "r"(stride));
+  VCMP_U32(17, v1, 0, 0xf9aa71f0, 0, 0x99991348);
+}
+
+void TEST_CASE18(void) {
+#if ELEN == 64
+  VSET(8, e64, m2);
+  volatile uint64_t INP1[] = {
+      0x9fe419208f2e05e0, 0xf9aa71f0c394bbd3, 0xa11a9384a7163840,
+      0x99991348a9f38cd1, 0x9fa831c7a11a9384, 0x3819759853987548,
+      0x1893179501093489, 0x81937598aa819388, 0x1874754791888188,
+      0x3eeeeeeee33111ae, 0x9013930148815808, 0xab8b914891484891,
+      0x9031850931584902, 0x3189759837598759, 0x8319599991911111,
+      0x8913984898951989};
+  uint64_t stride = 16;
+  VLOAD_8(v0, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vlse64.v v2, (%0), %1, v0.t" ::"r"(INP1), "r"(stride));
+  VCMP_U64(18, v2, 0, 0xa11a9384a7163840, 0, 0x1893179501093489, 0,
+           0x9013930148815808, 0, 0x8319599991911111);
+#endif
+}
+
+// Large vector lengths
+void TEST_CASE19(void) {
+  VSET(128, e8, m4);
+  volatile uint8_t INP1[] = {0x3d, 0x7c, 0xa1, 0x52, 0xf3, 0x0b, 0x86, 0xc9,
+                             0x4e, 0x17, 0xda, 0x63, 0x95, 0x2f, 0x71, 0xb8,
+                             0x08, 0xe5, 0x3a, 0x6d, 0xc4, 0x90, 0x5b, 0x27,
+                             0xfe, 0x44, 0x13, 0x79, 0xab, 0xd6, 0x61, 0x1c,
+                             0x82, 0x3f, 0xee, 0x55, 0x09, 0xbc, 0x74, 0x30,
+                             0xcb, 0x6a, 0xf7, 0x21, 0x9e, 0x48, 0xd3, 0x8c,
+                             0x15, 0x70, 0xa7, 0x4b, 0xe0, 0x2d, 0x93, 0x5f,
+                             0xb4, 0x39, 0x67, 0x0c, 0xdf, 0x84, 0x1a, 0x46,
+                             0xfe, 0x44, 0x13, 0x79, 0xab, 0xd6, 0x61, 0x1c,
+                             0x82, 0x3f, 0xee, 0x55, 0x09, 0xbc, 0x74, 0x30,
+                             0xcb, 0x6a, 0xf7, 0x21, 0x9e, 0x48, 0xd3, 0x8c,
+                             0x15, 0x70, 0xa7, 0x4b, 0xe0, 0x2d, 0x93, 0x5f,
+                             0xb4, 0x39, 0x67, 0x0c, 0xdf, 0x84, 0x1a, 0x46,
+                             0xcb, 0x6a, 0xf7, 0x21, 0x9e, 0x48, 0xd3, 0x8c,
+                             0x15, 0x70, 0xa7, 0x4b, 0xe0, 0x2d, 0x93, 0x5f,
+                             0xb4, 0x39, 0x67, 0x0c, 0xdf, 0x84, 0x1a, 0x46};
+  uint64_t stride = 1;
+  asm volatile("vlse8.v v4, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U8(19, v4, 0x3d, 0x7c, 0xa1, 0x52, 0xf3, 0x0b, 0x86, 0xc9,
+                             0x4e, 0x17, 0xda, 0x63, 0x95, 0x2f, 0x71, 0xb8,
+                             0x08, 0xe5, 0x3a, 0x6d, 0xc4, 0x90, 0x5b, 0x27,
+                             0xfe, 0x44, 0x13, 0x79, 0xab, 0xd6, 0x61, 0x1c,
+                             0x82, 0x3f, 0xee, 0x55, 0x09, 0xbc, 0x74, 0x30,
+                             0xcb, 0x6a, 0xf7, 0x21, 0x9e, 0x48, 0xd3, 0x8c,
+                             0x15, 0x70, 0xa7, 0x4b, 0xe0, 0x2d, 0x93, 0x5f,
+                             0xb4, 0x39, 0x67, 0x0c, 0xdf, 0x84, 0x1a, 0x46,
+                             0xfe, 0x44, 0x13, 0x79, 0xab, 0xd6, 0x61, 0x1c,
+                             0x82, 0x3f, 0xee, 0x55, 0x09, 0xbc, 0x74, 0x30,
+                             0xcb, 0x6a, 0xf7, 0x21, 0x9e, 0x48, 0xd3, 0x8c,
+                             0x15, 0x70, 0xa7, 0x4b, 0xe0, 0x2d, 0x93, 0x5f,
+                             0xb4, 0x39, 0x67, 0x0c, 0xdf, 0x84, 0x1a, 0x46,
+                             0xcb, 0x6a, 0xf7, 0x21, 0x9e, 0x48, 0xd3, 0x8c,
+                             0x15, 0x70, 0xa7, 0x4b, 0xe0, 0x2d, 0x93, 0x5f,
+                             0xb4, 0x39, 0x67, 0x0c, 0xdf, 0x84, 0x1a, 0x46);
+}
+
+void TEST_CASE20(void) {
+  VSET(64, e16, m4);
+  volatile uint16_t INP1[] = {0x7a3d, 0xc124, 0x5ef9, 0x80b7,
+                              0x2dd0, 0x91e2, 0x4b6c, 0xf813,
+                              0x36a5, 0xd47f, 0x0c98, 0xb2e1,
+                              0x695a, 0xe70d, 0x13c4, 0xacf6,
+                              0x41be, 0x9d73, 0x26e8, 0xf05c,
+                              0x7b12, 0xc9af, 0x58d4, 0x0e67,
+                              0xb84a, 0x3fd1, 0xe295, 0x649c,
+                              0x1ab0, 0x95e6, 0x4c3b, 0xda78,
+                              0x2f1d, 0x83c6, 0x6e50, 0xb79a,
+                              0x145f, 0xe8c3, 0x3974, 0xa2ed,
+                              0x5c81, 0xd6b4, 0x087a, 0xf193,
+                              0x72ce, 0x2a45, 0x9fb8, 0x4de0,
+                              0xc367, 0x1e9a, 0xb50f, 0x6842,
+                              0xfad1, 0x305c, 0x87e4, 0x5b29,
+                              0xdc70, 0x243f, 0x96a1, 0x4f8c,
+                              0xe312, 0x79d5, 0x0b6e, 0xc854,
+                            };
+  uint64_t stride = 2;
+  asm volatile("vlse16.v v4, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U16(20, v4, 0x7a3d, 0xc124, 0x5ef9, 0x80b7,
+                   0x2dd0, 0x91e2, 0x4b6c, 0xf813,
+                   0x36a5, 0xd47f, 0x0c98, 0xb2e1,
+                   0x695a, 0xe70d, 0x13c4, 0xacf6,
+                   0x41be, 0x9d73, 0x26e8, 0xf05c,
+                   0x7b12, 0xc9af, 0x58d4, 0x0e67,
+                   0xb84a, 0x3fd1, 0xe295, 0x649c,
+                   0x1ab0, 0x95e6, 0x4c3b, 0xda78,
+                   0x2f1d, 0x83c6, 0x6e50, 0xb79a,
+                   0x145f, 0xe8c3, 0x3974, 0xa2ed,
+                   0x5c81, 0xd6b4, 0x087a, 0xf193,
+                   0x72ce, 0x2a45, 0x9fb8, 0x4de0,
+                   0xc367, 0x1e9a, 0xb50f, 0x6842,
+                   0xfad1, 0x305c, 0x87e4, 0x5b29,
+                   0xdc70, 0x243f, 0x96a1, 0x4f8c,
+                   0xe312, 0x79d5, 0x0b6e, 0xc854);
+}
+
+void TEST_CASE21(void) {
+  VSET(32, e32, m4);
+  volatile uint32_t INP1[] = {0x8f31c4a7, 0x15be9072, 0xd26a4f1d, 0x7043e8b9,
+                              0x2cb59760, 0xfa1843de, 0x61d90a85, 0x9374bc2f,
+                              0x4ea12d68, 0xb8f06c13, 0x07cd52f1, 0xe39b847a,
+                              0x596ef320, 0xacc1459d, 0x3b7288e4, 0xc6d0175b,
+                              0x03430f29, 0x7a1b2c86, 0xf8e5d3c4, 0x9b6a1e72,
+                              0x5c8f4a1d, 0xe2b36d14, 0x48f7a9c3, 0x1d0e5b8a,
+                              0x6f2c9d57, 0xa7b8c4e1, 0x2d3f6a98, 0x83e1b745,
+                              0x4c9a2ddf, 0xf1e8a6b2, 0x9d73c5e8, 0x60a1f394};
+  uint64_t stride = 4;
+  asm volatile("vlse32.v v4, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U32(21, v4, 0x8f31c4a7, 0x15be9072, 0xd26a4f1d, 0x7043e8b9,
+                   0x2cb59760, 0xfa1843de, 0x61d90a85, 0x9374bc2f,
+                   0x4ea12d68, 0xb8f06c13, 0x07cd52f1, 0xe39b847a,
+                   0x596ef320, 0xacc1459d, 0x3b7288e4, 0xc6d0175b,
+                   0x03430f29, 0x7a1b2c86, 0xf8e5d3c4, 0x9b6a1e72,
+                   0x5c8f4a1d, 0xe2b36d14, 0x48f7a9c3, 0x1d0e5b8a,
+                   0x6f2c9d57, 0xa7b8c4e1, 0x2d3f6a98, 0x83e1b745,
+                   0x4c9a2ddf, 0xf1e8a6b2, 0x9d73c5e8, 0x60a1f394);
+}
+
+void TEST_CASE22(void) {
+#if ELEN == 64
+  VSET(16, e64, m4);
+  volatile uint64_t INP1[] = {0x7c31e9a5d0428f16, 0xb57a0c6e913df248,
+                              0x18d4fa709c25be63, 0xe2b36d1487f950ac,
+                              0x49cf825ab31e670d, 0x96a1780fe4d2cb35,
+                              0x2df05c93a86b1741, 0xc8e49b26751adf90,
+                              0x7c31e9245d0428f1, 0xb57a0c6e913df248,
+                              0x18d4fa709c259be6, 0x3db36d1487f950ac,
+                              0x49cf825ab31e670d, 0x96a1ffffe4d2cb35,
+                              0x2df05c937b6b1741, 0xc8e2cb26751adf90};
+  uint64_t stride = 8;
+  asm volatile("vlse64.v v4, (%0), %1" ::"r"(INP1), "r"(stride));
+  VCMP_U64(22, v4, 0x7c31e9a5d0428f16, 0xb57a0c6e913df248,
+                   0x18d4fa709c25be63, 0xe2b36d1487f950ac,
+                   0x49cf825ab31e670d, 0x96a1780fe4d2cb35,
+                   0x2df05c93a86b1741, 0xc8e49b26751adf90,
+                   0x7c31e9245d0428f1, 0xb57a0c6e913df248,
+                   0x18d4fa709c259be6, 0x3db36d1487f950ac,
+                   0x49cf825ab31e670d, 0x96a1ffffe4d2cb35,
+                   0x2df05c937b6b1741, 0xc8e2cb26751adf90);
+#endif
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  // Positive-stride tests
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+
+  TEST_CASE5();
+  TEST_CASE6();
+  TEST_CASE7();
+  TEST_CASE8();
+
+  // Zero-stride tests
+  TEST_CASE9();
+  TEST_CASE10();
+  TEST_CASE11();
+
+  // Negative-stride test
+  TEST_CASE12();
+  // Stride > SpatzMemBytes (default)
+  TEST_CASE13();
+  // Fill Spatz register
+  TEST_CASE14();
+
+  // TODO: Masked stride loads
+  // TEST_CASE15();
+  // TEST_CASE16();
+  // TEST_CASE17();
+  // TEST_CASE18();
+
+  // Large vector lengths
+  TEST_CASE19();
+  TEST_CASE20();
+  TEST_CASE21();
+  TEST_CASE22();
+
+  EXIT_CHECK();
+}


### PR DESCRIPTION
## Fixed
1. **Simpler synchronization for both double-bandwidth interfaces**. Both interfaces now always commit together. If interface1 conflicts at the VRF, it is buffered. Interface1 is always the one that sends the response to the controller to retire the instruction.
2. **Fix address generation for strided loads** in double bandwidth vlsu

## Added
1. Instruction test for strided loads `vlse`