### PR TITLE
[SW] Adding check during init of vector registers

### DIFF
--- a/sw/snRuntime/src/start.S.in
+++ b/sw/snRuntime/src/start.S.in
@@ -15,7 +15,7 @@ _start:
 snrt.crt0.init_vec_registers:
     # Check if core has vector registers, otherwise skip
     csrr    t0, misa
-    li      t1, (1 << 21)    
+    li      t1, (1 << 21)
     and     t0, t0, t1       # check 'V' extension (bit 21 = 'V')
     beqz    t0, snrt.crt0.init_fp_registers
     li      t0, -1

--- a/sw/snRuntime/src/start.S.in
+++ b/sw/snRuntime/src/start.S.in
@@ -13,8 +13,13 @@ _start:
     .globl _start
 
 snrt.crt0.init_vec_registers:
-    li t0, -1
-    vsetvli	zero, t0, e32, m8, ta, ma
+    # Check if core has vector registers, otherwise skip
+    csrr    t0, misa
+    li      t1, (1 << 21)    
+    and     t0, t0, t1       # check 'V' extension (bit 21 = 'V')
+    beqz    t0, snrt.crt0.init_fp_registers
+    li      t0, -1
+    vsetvli zero, t0, e32, m8, ta, ma
     vmv.v.i v0, 0
     vmv.v.i v8, 0
     vmv.v.i v16, 0


### PR DESCRIPTION
Fix `sw/snRuntime/src/start.S.in` to check whether the Vector extension is supported before enabling vector initialization during boot
