### PR TITLE
hw: comb loop fix double bw vlsu

### DIFF
--- a/hw/ip/spatz/src/spatz_vrf.sv
+++ b/hw/ip/spatz/src/spatz_vrf.sv
@@ -108,7 +108,7 @@ module spatz_vrf
     for (int unsigned bank = 0; bank < NrVRFBanks; bank++) begin
 `ifdef BUF_FPU
 `ifdef DOUBLE_BW
-      automatic logic write_request_vlsu = write_request[bank][VLSU_VD_WD0] | write_request[bank][VLSU_VD_WD1];
+      automatic logic write_request_vlsu = write_request[bank][VLSU_VD_WD0];
 `else
       automatic logic write_request_vlsu = write_request[bank][VLSU_VD_WD];
 `endif


### PR DESCRIPTION
To fix a comb loop path in double bandwidth vlsu. If vlsu1 writes to bank1 while vlsu0 and vfu try to write to bank0, if vfu_buf is full, vlsu0 will be stalled to prioritize vfu. This means vlsu0 is stalled, and since interfaces are synchronized vlsu1 should also be stalled hence no write should be allowed from vlsu1, which is a timing loop.
Fix is to check only vlsu0 conflict with vfu.