### PR TITLE
[snitch] NaN-box narrow FP loads (flw) in the LSU return path

### DIFF
--- a/hw/ip/snitch/src/snitch_lsu.sv
+++ b/hw/ip/snitch/src/snitch_lsu.sv
@@ -165,9 +165,15 @@ module snitch_lsu #(
   assign shifted_data = data_rsp_i.p.data >> {laq_out.offset, 3'b000};
   always_comb begin
     unique case (laq_out.size)
-      2'b00: ld_result = {{56{(shifted_data[7] | NaNBox) & laq_out.sign_ext}}, shifted_data[7:0]};
-      2'b01: ld_result = {{48{(shifted_data[15] | NaNBox) & laq_out.sign_ext}}, shifted_data[15:0]};
-      2'b10: ld_result = {{32{(shifted_data[31] | NaNBox) & laq_out.sign_ext}}, shifted_data[31:0]};
+      // NaN-boxing a narrow FP load into a wider FP register is unconditional per
+      // the RISC-V spec, so it must not be gated on sign-extension. The original
+      // (data[msb] | NaNBox) & sign_ext dropped the boxing when sign_ext=0, which
+      // is always so for the FP LSU (fp_lsu_qsigned=0), so flw zero-extended. The
+      // rewritten (data[msb] & sign_ext) | NaNBox is bit-identical for the integer
+      // LSU (NaNBox=0) and forces the upper bits to all-ones for the FP LSU.
+      2'b00: ld_result = {{56{(shifted_data[7]  & laq_out.sign_ext) | NaNBox}}, shifted_data[7:0]};
+      2'b01: ld_result = {{48{(shifted_data[15] & laq_out.sign_ext) | NaNBox}}, shifted_data[15:0]};
+      2'b10: ld_result = {{32{(shifted_data[31] & laq_out.sign_ext) | NaNBox}}, shifted_data[31:0]};
       2'b11: ld_result = shifted_data;
       default: ld_result = shifted_data;
     endcase

--- a/hw/ip/snitch/src/snitch_lsu.sv
+++ b/hw/ip/snitch/src/snitch_lsu.sv
@@ -165,12 +165,8 @@ module snitch_lsu #(
   assign shifted_data = data_rsp_i.p.data >> {laq_out.offset, 3'b000};
   always_comb begin
     unique case (laq_out.size)
-      // NaN-boxing a narrow FP load into a wider FP register is unconditional per
-      // the RISC-V spec, so it must not be gated on sign-extension. The original
-      // (data[msb] | NaNBox) & sign_ext dropped the boxing when sign_ext=0, which
-      // is always so for the FP LSU (fp_lsu_qsigned=0), so flw zero-extended. The
-      // rewritten (data[msb] & sign_ext) | NaNBox is bit-identical for the integer
-      // LSU (NaNBox=0) and forces the upper bits to all-ones for the FP LSU.
+      // Narrow FP loads NaN-box unconditionally (upper bits all 1s) rather than
+      // sign-extend; sign_ext only applies to integer loads (NaNBox = 0).
       2'b00: ld_result = {{56{(shifted_data[7]  & laq_out.sign_ext) | NaNBox}}, shifted_data[7:0]};
       2'b01: ld_result = {{48{(shifted_data[15] & laq_out.sign_ext) | NaNBox}}, shifted_data[15:0]};
       2'b10: ld_result = {{32{(shifted_data[31] & laq_out.sign_ext) | NaNBox}}, shifted_data[31:0]};

--- a/sw/riscvTests/CMakeLists.txt
+++ b/sw/riscvTests/CMakeLists.txt
@@ -142,6 +142,7 @@ add_snitch_test(vfcvt  isa/rv64uv/vfcvt.c)
 add_snitch_test(vfncvt isa/rv64uv/vfncvt.c)
 
 add_snitch_test(vfmv isa/rv64uv/vfmv.c)
+add_snitch_test(fl_narrow isa/rv64uv/fl_narrow.c)
 
 add_snitch_test(invalid isa/rv64uv/invalid.c)
 set_property(TEST ${SNITCH_TEST_PREFIX}rtl-invalid PROPERTY WILL_FAIL TRUE)

--- a/sw/riscvTests/isa/rv64uv/fl_narrow.c
+++ b/sw/riscvTests/isa/rv64uv/fl_narrow.c
@@ -1,0 +1,114 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Check NaN-boxing of narrow FP loads (flw/flh/flb) in the LSU return path,
+// and that integer loads are unaffected. The box bits are observed by reading
+// the FPR back wider than the load wrote it.
+
+#include "vector_macros.h"
+
+// flw must NaN-box FPR bits [63:32] to all 1s; fsd exposes them.
+// Only meaningful (and fsd only legal) on RVD configs.
+#if ELEN == 64
+void TEST_CASE1(void) {
+  volatile uint32_t src;
+  volatile uint32_t dst[2] __attribute__((aligned(8)));
+  src = 0x3F800000; // 1.0 (fp32)
+  dst[0] = 0;
+  dst[1] = 0;
+  asm volatile("fence\n"
+               "flw fa0, 0(%[src])\n"
+               "fsd fa0, 0(%[dst])\n"
+               "fence\n"
+               :
+               : [src] "r"(&src), [dst] "r"(dst)
+               : "fa0", "memory");
+  XCMP(1, dst[0], (uint32_t)0x3F800000);
+  XCMP(2, dst[1], (uint32_t)0xFFFFFFFF);
+}
+#endif
+
+// flh must NaN-box FPR bits [63:16] to all 1s; fmv.x.s exposes [31:16]
+void TEST_CASE2(void) {
+  volatile uint32_t src = 0x00003C00; // 1.0 (fp16) in the low halfword
+  register const volatile uint32_t *addr asm("a0") = &src;
+  register uint32_t out asm("a1") = 0;
+  asm volatile("fence\n"
+               "flh fa0, 0(a0)\n"
+               "fmv.x.s a1, fa0\n"
+               : "+r"(out)
+               : "r"(addr)
+               : "fa0", "memory");
+  XCMP(3, out, (uint32_t)0xFFFF3C00);
+}
+
+// flb must NaN-box FPR bits [63:8] to all 1s; fmv.x.s exposes [31:8]
+void TEST_CASE3(void) {
+  volatile uint32_t src = 0x00000038; // 1.0 (fp8) in the low byte
+  register const volatile uint32_t *addr asm("a0") = &src;
+  register uint32_t out asm("a1") = 0;
+  asm volatile("fence\n"
+               "flb fa0, 0(a0)\n"
+               "fmv.x.s a1, fa0\n"
+               : "+r"(out)
+               : "r"(addr)
+               : "fa0", "memory");
+  XCMP(4, out, (uint32_t)0xFFFFFF38);
+}
+
+// Integer loads go through the same rewritten expression with NaNBox=0 and
+// must keep sign/zero-extending as before
+void TEST_CASE4(void) {
+  volatile uint32_t src = 0x00008080; // sign bits set for both lh and lb
+  uint32_t h, hu, b, bu;
+  asm volatile("lh  %[h],  0(%[src])\n"
+               "lhu %[hu], 0(%[src])\n"
+               "lb  %[b],  0(%[src])\n"
+               "lbu %[bu], 0(%[src])\n"
+               : [h] "=r"(h), [hu] "=r"(hu), [b] "=r"(b), [bu] "=r"(bu)
+               : [src] "r"(&src));
+  XCMP(5, h, (uint32_t)0xFFFF8080);
+  XCMP(6, hu, (uint32_t)0x00008080);
+  XCMP(7, b, (uint32_t)0xFFFFFF80);
+  XCMP(8, bu, (uint32_t)0x00000080);
+}
+
+// Full-width fld control: value passes through unmodified
+#if ELEN == 64
+void TEST_CASE5(void) {
+  volatile uint32_t src[2] __attribute__((aligned(8)));
+  volatile uint32_t dst[2] __attribute__((aligned(8)));
+  src[0] = 0x00000000; // 1.0 (fp64) = 0x3FF0000000000000
+  src[1] = 0x3FF00000;
+  dst[0] = 0;
+  dst[1] = 0;
+  asm volatile("fence\n"
+               "fld fa0, 0(%[src])\n"
+               "fsd fa0, 0(%[dst])\n"
+               "fence\n"
+               :
+               : [src] "r"(src), [dst] "r"(dst)
+               : "fa0", "memory");
+  XCMP(9, dst[0], (uint32_t)0x00000000);
+  XCMP(10, dst[1], (uint32_t)0x3FF00000);
+}
+#endif
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  enable_fp();
+
+#if ELEN == 64
+  TEST_CASE1();
+#endif
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+#if ELEN == 64
+  TEST_CASE5();
+#endif
+
+  EXIT_CHECK();
+}


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

flw does not NaN-box the loaded single-precision value. The FP LSU ties
fp_lsu_qsigned to 0, and the load return path gated NaN-boxing on
sign-extension (`(data[msb] | NaNBox) & sign_ext`), so the boxing was dropped
and flw zero-extended into the 64-bit FP register. When a later
double-precision instruction reads that register it sees an ordinary number
where the spec requires a NaN, and its result diverges from the reference.

The fix makes NaN-boxing unconditional in the load return path
(`(data[msb] & sign_ext) | NaNBox`). It is bit-identical for the integer LSU
(NaNBox=0) and forces the upper bits to all-ones for the FP LSU.