### PR TITLE
Fix reduction behavior

### DIFF
--- a/hw/ip/spatz/src/spatz_vfu.sv
+++ b/hw/ip/spatz/src/spatz_vfu.sv
@@ -309,7 +309,7 @@ module spatz_vfu
     end
 
     // An instruction finished execution
-    if ((result_tag.last && &(result_valid | ~pending_results) && reduction_state_q inside {Reduction_NormalExecution, Reduction_Wait}) || reduction_done) begin
+    if ((result_tag.last && &(result_valid | ~pending_results) && (reduction_state_q inside {Reduction_NormalExecution, Reduction_Wait} || ! result_tag.reduction)) || reduction_done) begin
       vfu_rsp_o.id      = result_tag.id;
       vfu_rsp_o.rd      = result_tag.vd_addr[GPRWidth-1:0];
       vfu_rsp_o.wb      = result_tag.wb;


### PR DESCRIPTION
A reduction instruction whose operand depends on a preceding arithmetic instruction can deadlock: once the reduction enters the Reduction_Reduce stage. The preceding instruction's retire condition in control_proc is never satisfied — it can't retire and release its result. The reduction, in turn, is stuck waiting on that same result. That creates a deadlock.
Code example:
        asm volatile("vsetvli %0, %1, e8, m8, ta, ma" : "=r"(vl) : "r"(64));
        asm volatile("vmv.v.i v0, 1");           
        asm volatile("vrsub.vi v16, v0, 0");      
        asm volatile("vmv.v.i v24, -1");         
        asm volatile("vredand.vs v8, v16, v24"); 
        asm volatile("vmv.x.s %0, v8" : "=r"(result));
A solution is to add a check to control_proc that non-reduction instructions can retire regardless of reduction_state_q