### PR TITLE
[Fix] Decoder uses vtype.vill to decide if instruction is legal

### DIFF
--- a/hw/ip/spatz/src/spatz_decoder.sv
+++ b/hw/ip/spatz/src/spatz_decoder.sv
@@ -408,6 +408,10 @@ module spatz_decoder
           spatz_req.vd          = arith_d;
           spatz_req.ex_unit     = VFU;
 
+          if (spatz_req.vtype.vill) begin
+            illegal_instr = 1'b1;
+          end
+
           // Decide which operands to use (vs1 or rs1 or imm)
           unique case (func3)
             OPIVV,
@@ -918,6 +922,10 @@ module spatz_decoder
           automatic vreg_t arith_s2 = decoder_req_i.instr[24:20];
           automatic vreg_t arith_d  = decoder_req_i.instr[11:7];
 
+          if (spatz_req.vtype.vill) begin
+            illegal_instr = 1'b1;
+          end
+
           spatz_req.op                 = VADD;
           spatz_req.ex_unit            = VFU;
           spatz_req.rd                 = arith_d;
@@ -1034,6 +1042,10 @@ module spatz_decoder
             spatz_req.ex_unit     = VFU;
             spatz_req.rm          = fpu_rnd_mode_i;
             spatz_req.fm          = fpu_fmt_mode_i;
+
+            if (spatz_req.vtype.vill) begin
+              illegal_instr = 1'b1;
+            end
 
             // Decide which operands to use (vs2 or rs1 or imm)
             unique case (func3)
@@ -1479,6 +1491,10 @@ module spatz_decoder
             automatic vreg_t arith_s2 = decoder_req_i.instr[24:20];
             automatic vreg_t arith_d  = decoder_req_i.instr[11:7];
 
+            if (spatz_req.vtype.vill) begin
+              illegal_instr = 1'b1;
+            end
+
             spatz_req.op                 = VADD;
             spatz_req.ex_unit            = VFU;
             spatz_req.rd                 = arith_d;
@@ -1505,6 +1521,10 @@ module spatz_decoder
           spatz_req.vtype.vsew         = EW_32;
           spatz_req.op_arith.is_scalar = 1'b1;
 
+          if (spatz_req.vtype.vill) begin
+            illegal_instr = 1'b1;
+          end
+
           unique casez (decoder_req_i.instr)
             riscv_instr::MUL   : spatz_req.op = VMUL;
             riscv_instr::MULH  : spatz_req.op = VMULH;
@@ -1527,6 +1547,10 @@ module spatz_decoder
           spatz_req.rs2                = decoder_req_i.rs1;
           spatz_req.vtype.vsew         = EW_32;
           spatz_req.op_arith.is_scalar = 1'b1;
+
+          if (spatz_req.vtype.vill) begin
+            illegal_instr = 1'b1;
+          end
 
           unique casez (decoder_req_i.instr)
             riscv_instr::DIV : spatz_req.op = VDIV;
@@ -1571,6 +1595,10 @@ module spatz_decoder
             spatz_req.rm                 = fpu_rnd_mode_i;
             spatz_req.fm                 = fpu_fmt_mode_i;
             spatz_req.vtype.vsew         = EW_8;
+
+            if (spatz_req.vtype.vill) begin
+              illegal_instr = 1'b1;
+            end
 
             unique casez (decoder_req_i.instr)
               riscv_instr::FADD_B : spatz_req.op = VFADD;
@@ -1675,6 +1703,10 @@ module spatz_decoder
             spatz_req.rm                 = fpu_rnd_mode_i;
             spatz_req.fm                 = fpu_fmt_mode_i;
             spatz_req.vtype.vsew         = EW_16;
+
+            if (spatz_req.vtype.vill) begin
+              illegal_instr = 1'b1;
+            end
 
             unique casez (decoder_req_i.instr)
               riscv_instr::FADD_H : spatz_req.op = VFADD;
@@ -1781,6 +1813,10 @@ module spatz_decoder
             spatz_req.fm                 = fpu_fmt_mode_i;
             spatz_req.vtype.vsew         = EW_32;
 
+            if (spatz_req.vtype.vill) begin
+              illegal_instr = 1'b1;
+            end
+
             unique casez (decoder_req_i.instr)
               riscv_instr::FADD_S : spatz_req.op = VFADD;
               riscv_instr::FSUB_S : begin
@@ -1883,6 +1919,10 @@ module spatz_decoder
             spatz_req.rm                 = fpu_rnd_mode_i;
             spatz_req.fm                 = fpu_fmt_mode_i;
             spatz_req.vtype.vsew         = EW_64;
+
+            if (spatz_req.vtype.vill) begin
+              illegal_instr = 1'b1;
+            end
 
             unique casez (decoder_req_i.instr)
               riscv_instr::FADD_D : spatz_req.op = VFADD;

--- a/hw/ip/spatz/src/spatz_decoder.sv
+++ b/hw/ip/spatz/src/spatz_decoder.sv
@@ -408,7 +408,7 @@ module spatz_decoder
           spatz_req.vd          = arith_d;
           spatz_req.ex_unit     = VFU;
 
-          if (spatz_req.vtype.vill) begin
+          if (decoder_req_i.vtype.vill) begin
             illegal_instr = 1'b1;
           end
 
@@ -922,7 +922,7 @@ module spatz_decoder
           automatic vreg_t arith_s2 = decoder_req_i.instr[24:20];
           automatic vreg_t arith_d  = decoder_req_i.instr[11:7];
 
-          if (spatz_req.vtype.vill) begin
+          if (decoder_req_i.vtype.vill) begin
             illegal_instr = 1'b1;
           end
 
@@ -1043,7 +1043,7 @@ module spatz_decoder
             spatz_req.rm          = fpu_rnd_mode_i;
             spatz_req.fm          = fpu_fmt_mode_i;
 
-            if (spatz_req.vtype.vill) begin
+            if (decoder_req_i.vtype.vill) begin
               illegal_instr = 1'b1;
             end
 
@@ -1491,7 +1491,7 @@ module spatz_decoder
             automatic vreg_t arith_s2 = decoder_req_i.instr[24:20];
             automatic vreg_t arith_d  = decoder_req_i.instr[11:7];
 
-            if (spatz_req.vtype.vill) begin
+            if (decoder_req_i.vtype.vill) begin
               illegal_instr = 1'b1;
             end
 
@@ -1521,7 +1521,7 @@ module spatz_decoder
           spatz_req.vtype.vsew         = EW_32;
           spatz_req.op_arith.is_scalar = 1'b1;
 
-          if (spatz_req.vtype.vill) begin
+          if (decoder_req_i.vtype.vill) begin
             illegal_instr = 1'b1;
           end
 
@@ -1548,7 +1548,7 @@ module spatz_decoder
           spatz_req.vtype.vsew         = EW_32;
           spatz_req.op_arith.is_scalar = 1'b1;
 
-          if (spatz_req.vtype.vill) begin
+          if (decoder_req_i.vtype.vill) begin
             illegal_instr = 1'b1;
           end
 
@@ -1596,7 +1596,7 @@ module spatz_decoder
             spatz_req.fm                 = fpu_fmt_mode_i;
             spatz_req.vtype.vsew         = EW_8;
 
-            if (spatz_req.vtype.vill) begin
+            if (decoder_req_i.vtype.vill) begin
               illegal_instr = 1'b1;
             end
 
@@ -1704,7 +1704,7 @@ module spatz_decoder
             spatz_req.fm                 = fpu_fmt_mode_i;
             spatz_req.vtype.vsew         = EW_16;
 
-            if (spatz_req.vtype.vill) begin
+            if (decoder_req_i.vtype.vill) begin
               illegal_instr = 1'b1;
             end
 
@@ -1813,7 +1813,7 @@ module spatz_decoder
             spatz_req.fm                 = fpu_fmt_mode_i;
             spatz_req.vtype.vsew         = EW_32;
 
-            if (spatz_req.vtype.vill) begin
+            if (decoder_req_i.vtype.vill) begin
               illegal_instr = 1'b1;
             end
 
@@ -1920,7 +1920,7 @@ module spatz_decoder
             spatz_req.fm                 = fpu_fmt_mode_i;
             spatz_req.vtype.vsew         = EW_64;
 
-            if (spatz_req.vtype.vill) begin
+            if (decoder_req_i.vtype.vill) begin
               illegal_instr = 1'b1;
             end
 

--- a/sw/riscvTests/CMakeLists.txt
+++ b/sw/riscvTests/CMakeLists.txt
@@ -165,3 +165,6 @@ add_snitch_test(vse16 isa/rv64uv/vse16.c)
 add_snitch_test(vse32 isa/rv64uv/vse32.c)
 add_snitch_test(vse64 isa/rv64uv/vse64.c)
 add_snitch_test(vss isa/rv64uv/vss.c)
+
+add_snitch_test(vill isa/rv64uv/vill.c)
+set_property(TEST ${SNITCH_TEST_PREFIX}rtl-invalid PROPERTY WILL_FAIL TRUE)

--- a/sw/riscvTests/isa/rv64uv/vill.c
+++ b/sw/riscvTests/isa/rv64uv/vill.c
@@ -1,0 +1,15 @@
+#include "vector_macros.h"
+
+int main(void) {
+
+  unsigned int vtype = 1 << 31;
+
+  __asm__ volatile (
+      "li      t0, -1 \n"
+      "vsetvl zero, zero, t0 \n"
+  );
+
+  asm volatile("vadd.vv v24, v8, v16");
+
+  return 0;
+}


### PR DESCRIPTION
According to the spec, if vill is set, any vector instructions that depends on vtype, must be considered an illegal instructions.
See [RISCV unpriv. 30.1.3.4.4. Vector Type Illegal (vill)](https://docs.riscv.org/reference/isa/v20260120/unpriv/v-st-ext.html#30-1-3-4-4-vector-type-illegal-vill)


In these cases the `decoder_rsp_o.instr_illegal` remained `'0`.
This made the `spatz_controller` set `spatz_req_valid`, and made it send the request the execution units.
This means that an illegal instruction could generate a valid spatz request, that could result in memory accesses or updates of the register file.

This change will make `decoder_rsp_o.instr_illegal=1` for instructions that depend on vtype when `vtype_q.vill=1`.
