### PR TITLE
Fix NaN-boxing and sign extension of narrow scalar FP moves

### DIFF
--- a/hw/ip/spatz/src/spatz_fpu_sequencer.sv
+++ b/hw/ip/spatz/src/spatz_fpu_sequencer.sv
@@ -726,9 +726,16 @@ module spatz_fpu_sequencer
     if (is_move && use_rd && operands_available) begin
       fp_move_result_i = spatz_rsp_t'{
         id     : issue_req_i.id,
-        data   : fpr_rdata[0],
         default: '0
       };
+      // FPR->GPR moves with values narrower than XLEN must sign-extend the
+      // value; the FPR's upper (NaN-box) bits must not leak into the GPR.
+      unique casez (issue_req_i.data_op)
+        riscv_instr::FMV_X_S: fp_move_result_i.data = {{(FLEN-32){fpr_rdata[0][31]}}, fpr_rdata[0][31:0]};
+        riscv_instr::FMV_X_H: fp_move_result_i.data = {{(FLEN-16){fpr_rdata[0][15]}}, fpr_rdata[0][15:0]};
+        riscv_instr::FMV_X_B: fp_move_result_i.data = {{(FLEN- 8){fpr_rdata[0][ 7]}}, fpr_rdata[0][ 7:0]};
+        default:              fp_move_result_i.data = fpr_rdata[0];
+      endcase
       fp_move_result_valid_i = 1'b1;
     end
 

--- a/hw/ip/spatz/src/spatz_fpu_sequencer.sv
+++ b/hw/ip/spatz/src/spatz_fpu_sequencer.sv
@@ -774,7 +774,14 @@ module spatz_fpu_sequencer
     end
     // Commit moves to the RF
     else if (is_move && use_fd && !stall) begin
-      fpr_wdata[1] = issue_req_i.data_arga;
+      // GPR->FPR moves with values narrower than FLEN must be NaN-boxed.
+      // The upper bits of a valid NaN-boxed value must be all 1s.
+      unique casez (issue_req_i.data_op)
+        riscv_instr::FMV_S_X: fpr_wdata[1] = {{(FLEN-32){1'b1}}, issue_req_i.data_arga[31:0]};
+        riscv_instr::FMV_H_X: fpr_wdata[1] = {{(FLEN-16){1'b1}}, issue_req_i.data_arga[15:0]};
+        riscv_instr::FMV_B_X: fpr_wdata[1] = {{(FLEN- 8){1'b1}}, issue_req_i.data_arga[ 7:0]};
+        default:              fpr_wdata[1] = issue_req_i.data_arga;
+      endcase
       fpr_waddr[1] = fd;
       fpr_we[1]    = 1'b1;
     end

--- a/sw/riscvTests/CMakeLists.txt
+++ b/sw/riscvTests/CMakeLists.txt
@@ -142,6 +142,7 @@ add_snitch_test(vfcvt  isa/rv64uv/vfcvt.c)
 add_snitch_test(vfncvt isa/rv64uv/vfncvt.c)
 
 add_snitch_test(vfmv isa/rv64uv/vfmv.c)
+add_snitch_test(fmv_narrow isa/rv64uv/fmv_narrow.c)
 
 add_snitch_test(invalid isa/rv64uv/invalid.c)
 set_property(TEST ${SNITCH_TEST_PREFIX}rtl-invalid PROPERTY WILL_FAIL TRUE)

--- a/sw/riscvTests/isa/rv64uv/fmv_narrow.c
+++ b/sw/riscvTests/isa/rv64uv/fmv_narrow.c
@@ -1,0 +1,119 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Check sign extension of narrow FPR->GPR moves (fmv.x.h / fmv.x.b).
+
+#include "vector_macros.h"
+
+// Positive half-float: fmv.x.h must zero the upper 16 GPR bits (sign bit 0)
+void TEST_CASE1(void) {
+  register uint32_t in asm("a0") = 0x00003C00; // 1.0 (fp16)
+  register uint32_t out asm("a1") = 0;
+  asm volatile("fmv.h.x fa0, a0\n"
+               "fmv.x.h a1, fa0\n"
+               : "+r"(out)
+               : "r"(in)
+               : "fa0");
+  XCMP(1, out, (uint32_t)0x00003C00);
+}
+
+// Negative half-float: fmv.x.h must set the upper 16 GPR bits (sign bit 1)
+void TEST_CASE2(void) {
+  register uint32_t in asm("a0") = 0x0000BC00; // -1.0 (fp16)
+  register uint32_t out asm("a1") = 0;
+  asm volatile("fmv.h.x fa0, a0\n"
+               "fmv.x.h a1, fa0\n"
+               : "+r"(out)
+               : "r"(in)
+               : "fa0");
+  XCMP(2, out, (uint32_t)0xFFFFBC00);
+}
+
+// Positive byte-float: fmv.x.b must zero the upper 24 GPR bits
+void TEST_CASE3(void) {
+  register uint32_t in asm("a0") = 0x00000038; // 1.0 (fp8)
+  register uint32_t out asm("a1") = 0;
+  asm volatile("fmv.b.x fa0, a0\n"
+               "fmv.x.b a1, fa0\n"
+               : "+r"(out)
+               : "r"(in)
+               : "fa0");
+  XCMP(3, out, (uint32_t)0x00000038);
+}
+
+// Control: fmv.x.s round-trip is width-exact on RV32
+void TEST_CASE4(void) {
+  register uint32_t in asm("a0") = 0x3F800000; // 1.0 (fp32)
+  register uint32_t out asm("a1") = 0;
+  asm volatile("fmv.s.x fa0, a0\n"
+               "fmv.x.s a1, fa0\n"
+               : "+r"(out)
+               : "r"(in)
+               : "fa0");
+  XCMP(4, out, (uint32_t)0x3F800000);
+}
+
+// NaN-boxing of narrow GPR->FPR moves: read the FPR back *wider* than the
+// move wrote it, so the box bits land in the GPR.
+
+// fmv.h.x must set FPR bits [FLEN-1:16] to all 1s; fmv.x.s exposes [31:16]
+void TEST_CASE5(void) {
+  register uint32_t in asm("a0") = 0x00003C00; // 1.0 (fp16), sign bit 0
+  register uint32_t out asm("a1") = 0;
+  asm volatile("fmv.h.x fa0, a0\n"
+               "fmv.x.s a1, fa0\n"
+               : "+r"(out)
+               : "r"(in)
+               : "fa0");
+  XCMP(5, out, (uint32_t)0xFFFF3C00);
+}
+
+// fmv.b.x must set FPR bits [FLEN-1:8] to all 1s; fmv.x.s exposes [31:8]
+void TEST_CASE6(void) {
+  register uint32_t in asm("a0") = 0x00000038; // 1.0 (fp8), sign bit 0
+  register uint32_t out asm("a1") = 0;
+  asm volatile("fmv.b.x fa0, a0\n"
+               "fmv.x.s a1, fa0\n"
+               : "+r"(out)
+               : "r"(in)
+               : "fa0");
+  XCMP(6, out, (uint32_t)0xFFFFFF38);
+}
+
+// fmv.s.x must set FPR bits [63:32] to all 1s; fsd exposes them.
+// Only meaningful (and fsd only legal) on RVD configs.
+#if ELEN == 64
+void TEST_CASE7(void) {
+  volatile uint32_t buf[2] __attribute__((aligned(8)));
+  buf[0] = 0;
+  buf[1] = 0;
+  uint32_t in = 0x3F800000; // 1.0 (fp32), positive: sign extension would be 0s
+  asm volatile("fmv.s.x fa0, %[in]\n"
+               "fsd fa0, 0(%[buf])\n"
+               "fence\n"
+               :
+               : [in] "r"(in), [buf] "r"(buf)
+               : "fa0", "memory");
+  XCMP(7, buf[0], (uint32_t)0x3F800000);
+  XCMP(8, buf[1], (uint32_t)0xFFFFFFFF);
+}
+#endif
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  enable_fp();
+
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+  TEST_CASE6();
+#if ELEN == 64
+  TEST_CASE7();
+#endif
+
+  EXIT_CHECK();
+}


### PR DESCRIPTION
## Summary
 The FPU sequencer mishandles both directions of narrow scalar moves between the GPR and FP register files:

- **GPR→FPR** (`fmv.s.x`, `fmv.h.x`, `fmv.b.x`): the value written to the FPR was the raw sign-extended operand from Snitch instead of a NaN-boxed one. Narrow values are required to be extended with '1.
- **FPR→GPR** (`fmv.x.h`, `fmv.x.b`): the move result forwarded the raw FPR word, so the upper GPR bits came from the NaN-box (all 1s) instead of sign-extending the narrow value. Positive half/byte float read back as `0xFFFFxxxx` / `0xFFFFFFxx`.

This PR fixes this issue by handling the different widths and extending / truncating accordingly.

## Testing
New regression test `riscvTests/fmv_narrow` covers both directions:

- TC1–TC4: FPR→GPR sign extension via round-trips (positive + negative half/byte, `fmv.x.s` control)
- TC5–TC7: GPR→FPR NaN-boxing, observed by reading the FPR back *wider* than the move wrote it (`fmv.x.s` for the 16/8-bit boxes, `fsd` for the upper 32 box bits on FLEN=64)