### PR TITLE
[hw] Keep the VFU in the FPU state until the result has drained

### DIFF
--- a/hw/ip/spatz/src/spatz_vfu.sv
+++ b/hw/ip/spatz/src/spatz_vfu.sv
@@ -275,8 +275,9 @@ module spatz_vfu
         end
         VFU_RunningFPU: begin
           // Only go back to the IPU state once the FPUs are no longer busy
+          // Busy can drop while a result is still emerging, so wait on that too
           if (!is_fpu_insn)
-            if (is_fpu_busy)
+            if (is_fpu_busy || (|fpu_result_valid))
               stall = 1'b1;
             else begin
               state_d = VFU_RunningIPU;
@@ -338,7 +339,8 @@ module spatz_vfu
       fpu_op           = fpnew_pkg::FMADD;
       fpu_op_mode      = 1'b0;
       fpu_vectorial_op = 1'b0;
-      is_fpu_busy      = |fpu_busy_q;
+      // Include fpu_busy_d to catch the cycle busy_o just rose
+      is_fpu_busy      = (|fpu_busy_q) || (|fpu_busy_d);
       fpu_src_fmt      = fpnew_pkg::FP32;
       fpu_dst_fmt      = fpnew_pkg::FP32;
       fpu_int_fmt      = fpnew_pkg::INT32;


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

## Problem

A vector op followed by a scalar FP op that writes an FP register can wedge the core with no trap.

The VFU state machine leaves `VFU_RunningFPU` when `is_fpu_busy` is low (`spatz_vfu.sv:279`), but
`is_fpu_busy` is `|fpu_busy_q` (`:341`), a registered copy of fpnew's `busy_o` that lags one cycle,
and it has no term for a result still in flight. So the machine transitions too early, and once
`state_q` is `VFU_RunningIPU` the state-keyed result mux (`:582`) returns the IPU side and the FP
writeback is swallowed. The FPU sequencer keeps the destination register scoreboarded forever, and
the next instruction that reads or writes it stalls. With both cores stalled Verilator reports
`Resource deadlock avoided`.

Two windows open the hole. On the cycle fpnew picks up the op, `busy_o` rises but `fpu_busy_q` is
still 0, so the gate sees 0 and transitions. On the cycle fpnew emits, `busy_o` falls while
`fpu_result_valid` is still asserted waiting for `result_ready`, and the transition one cycle later
hides the result the same way.

## Fix

Wait on the combinational `fpu_busy_d` as well as `fpu_busy_q`, and add `fpu_result_valid` to the
FPU-state exit gate:

```systemverilog
if (is_fpu_busy || (|fpu_result_valid))
  stall = 1'b1;
...
is_fpu_busy = (|fpu_busy_q) || (|fpu_busy_d);
```

The IPU side is untouched (`is_ipu_busy` is already combinational). `gen_no_fpu` is unaffected, both
new terms are 0 there. No new state.