### PR TITLE
[sw/test] Add upstream RISC-V scalar ISA tests (rv32u*) as RTL ctests

### DIFF
--- a/sw/riscvTests/CMakeLists.txt
+++ b/sw/riscvTests/CMakeLists.txt
@@ -164,3 +164,6 @@ add_snitch_test(vse16 isa/rv64uv/vse16.c)
 add_snitch_test(vse32 isa/rv64uv/vse32.c)
 add_snitch_test(vse64 isa/rv64uv/vse64.c)
 add_snitch_test(vss isa/rv64uv/vss.c)
+
+# Upstream scalar RISC-V ISA tests (rv32u*), built against stock env/p.
+include(${CMAKE_CURRENT_LIST_DIR}/RiscvIsaTests.cmake)

--- a/sw/riscvTests/RiscvIsaTests.cmake
+++ b/sw/riscvTests/RiscvIsaTests.cmake
@@ -13,10 +13,13 @@
 
 if (BUILD_TESTS)
   include(FetchContent)
+  # Patch `move` to mask spatz's non-standard fmode out of fcsr WPRI bits.
+  set(RVTESTS_PATCH ${CMAKE_CURRENT_LIST_DIR}/patches/move-fcsr-wpri.patch)
   FetchContent_Declare(riscv_tests
     GIT_REPOSITORY https://github.com/riscv-software-src/riscv-tests.git
     GIT_TAG        34e6b6d1e7936b526075432fb730d89148623484
-    GIT_SUBMODULES_RECURSE TRUE)
+    GIT_SUBMODULES_RECURSE TRUE
+    PATCH_COMMAND  sh -c "git apply --reverse --check '${RVTESTS_PATCH}' 2>/dev/null || git apply '${RVTESTS_PATCH}'")
   FetchContent_MakeAvailable(riscv_tests)
   set(RVTESTS_ROOT ${riscv_tests_SOURCE_DIR})
   set(RVTESTS_ISA  ${RVTESTS_ROOT}/isa)

--- a/sw/riscvTests/RiscvIsaTests.cmake
+++ b/sw/riscvTests/RiscvIsaTests.cmake
@@ -1,0 +1,87 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Upstream RISC-V ISA tests (github.com/riscv-software-src/riscv-tests).
+#
+# The unmodified upstream .S tests build against the stock riscv-tests `env/p`
+# environment (its own _start, trap handler, hart!=0 parking and tohost pass/fail)
+# and run as RTL ctests via ${SNITCH_SIMULATOR} -- hence no custom env and no
+# snRuntime linkage, unlike the sibling vector .c tests.
+#
+# Modelled on snitch_cluster's sw/riscv-tests/riscv-tests.mk.
+
+if (BUILD_TESTS)
+  include(FetchContent)
+  FetchContent_Declare(riscv_tests
+    GIT_REPOSITORY https://github.com/riscv-software-src/riscv-tests.git
+    GIT_TAG        34e6b6d1e7936b526075432fb730d89148623484
+    GIT_SUBMODULES_RECURSE TRUE)
+  FetchContent_MakeAvailable(riscv_tests)
+  set(RVTESTS_ROOT ${riscv_tests_SOURCE_DIR})
+  set(RVTESTS_ISA  ${RVTESTS_ROOT}/isa)
+  set(RVTESTS_ENV  ${RVTESTS_ROOT}/env/p)
+endif()
+
+if (BUILD_TESTS AND EXISTS ${RVTESTS_ENV}/riscv_test.h)
+  set(RVTESTS_EXTS rv32ui rv32um rv32uf rv32ud)
+
+  # Target capabilities. When OFF, the matching tests still build and run but are
+  # marked WILL_FAIL. Used for unimplemented instructions (e.g. fdiv).
+  option(RVTESTS_HAS_DIVSQRT    "Target implements hardware FP divide/sqrt"    OFF)
+  option(RVTESTS_HAS_MISALIGNED "Target handles misaligned data access in HW"  OFF)
+
+  function(add_riscv_isa_test ext name)
+    set(tgt test-${SNITCH_TEST_PREFIX}${ext}-p-${name})
+    add_executable(${tgt} ${RVTESTS_ISA}/${ext}/${name}.S)
+    set_target_properties(${tgt} PROPERTIES LINKER_LANGUAGE C)
+    target_include_directories(${tgt} PRIVATE
+      ${RVTESTS_ENV} ${RVTESTS_ISA}/macros/scalar)
+    # env/p provides its own crt/_start and linker script; do NOT link snRuntime.
+    target_link_options(${tgt} PRIVATE "SHELL:-T ${RVTESTS_ENV}/link.ld")
+    add_custom_command(TARGET ${tgt} POST_BUILD
+      COMMAND ${CMAKE_OBJDUMP} -dhS $<TARGET_FILE:${tgt}> > $<TARGET_FILE:${tgt}>.s)
+    add_snitch_raw_test_rtl(${SNITCH_TEST_PREFIX}rtl-${ext}-p-${name} ${tgt})
+    if ((NOT RVTESTS_HAS_DIVSQRT AND name STREQUAL "fdiv") OR
+        (NOT RVTESTS_HAS_MISALIGNED AND name STREQUAL "ma_data"))
+      set_tests_properties(${SNITCH_TEST_PREFIX}rtl-${ext}-p-${name}
+        PROPERTIES WILL_FAIL TRUE)
+    endif()
+  endfunction()
+
+  foreach(ext ${RVTESTS_EXTS})
+    set(frag ${RVTESTS_ISA}/${ext}/Makefrag)
+    if (NOT EXISTS ${frag})
+      message(WARNING "riscv-tests: missing ${frag}; skipping ${ext}")
+      continue()
+    endif()
+    # Parse the upstream "<ext>_sc_tests = ..." list rather than globbing, to
+    # honour its selection (e.g. rv32ud omits the unfinished move/structural tests).
+    file(STRINGS ${frag} fraglines)
+    set(collect OFF)
+    set(names "")
+    foreach(line ${fraglines})
+      if ("${line}" MATCHES "^${ext}_sc_tests[ \t]*=(.*)$")
+        set(rest "${CMAKE_MATCH_1}")
+        set(collect ON)
+      elseif (collect)
+        set(rest "${line}")
+      else()
+        set(rest "")
+      endif()
+      if (collect)
+        set(names "${names} ${rest}")
+        if (NOT "${line}" MATCHES "\\\\[ \t]*$")  # no trailing backslash -> last line
+          set(collect OFF)
+        endif()
+      endif()
+    endforeach()
+    # Extract bare test identifiers (ignores whitespace, comments, backslashes).
+    string(REGEX MATCHALL "[A-Za-z0-9_]+" namelist "${names}")
+    foreach(name ${namelist})
+      add_riscv_isa_test(${ext} ${name})
+    endforeach()
+    list(LENGTH namelist n)
+    message(STATUS "riscv-tests: ${ext} -> ${n} test(s)")
+  endforeach()
+endif()

--- a/sw/riscvTests/patches/move-fcsr-wpri.patch
+++ b/sw/riscvTests/patches/move-fcsr-wpri.patch
@@ -1,0 +1,23 @@
+diff --git a/isa/rv64uf/move.S b/isa/rv64uf/move.S
+index 60f7cf3..7acc1b3 100644
+--- a/isa/rv64uf/move.S
++++ b/isa/rv64uf/move.S
+@@ -15,12 +15,15 @@ RVTEST_RV64UF
+ RVTEST_CODE_BEGIN
+ 
+   TEST_CASE(2, a1, 1, csrwi fcsr, 1; li a0, 0x1234; fssr a1, a0)
+-  TEST_CASE(3, a0, 0x34, frsr a0)
++  # andi: mask fcsr[9:8], spatz's non-standard fmode leaking into WPRI bits
++  TEST_CASE(3, a0, 0x34, frsr a0; andi a0, a0, 0xff)
+   TEST_CASE(4, a0, 0x14, frflags a0)
+   TEST_CASE(5, a0, 0x01, csrrwi a0, frm, 2)
+-  TEST_CASE(6, a0, 0x54, frsr a0)
++  # andi: mask fcsr[9:8], spatz's non-standard fmode leaking into WPRI bits
++  TEST_CASE(6, a0, 0x54, frsr a0; andi a0, a0, 0xff)
+   TEST_CASE(7, a0, 0x14, csrrci a0, fflags, 4)
+-  TEST_CASE(8, a0, 0x50, frsr a0)
++  # andi: mask fcsr[9:8], spatz's non-standard fmode leaking into WPRI bits
++  TEST_CASE(8, a0, 0x50, frsr a0; andi a0, a0, 0xff)
+ 
+ #define TEST_FSGNJS(n, insn, new_sign, rs1_sign, rs2_sign) \
+   TEST_CASE(n, a0, 0x12345678 | (-(new_sign) << 31), \


### PR DESCRIPTION
## What

Adds the upstream [`riscv-software-src/riscv-tests`](https://github.com/riscv-software-src/riscv-tests) scalar suites (`rv32ui`, `rv32um`, `rv32uf`, `rv32ud`) to the build as RTL ctests, alongside the existing vector `.c` tests. This gives Spatz's scalar/FP core (Snitch + the FPU sequencer path) direct ISA-level coverage it previously lacked.

## How

- **`sw/riscvTests/RiscvIsaTests.cmake`** — `FetchContent` pulls riscv-tests at a pinned tag, builds each test against the stock `env/p` (its own `_start`, trap handler, `tohost` pass/fail), and registers it as an RTL ctest via `${SNITCH_SIMULATOR}`. No snRuntime linkage. The per-suite `<ext>_sc_tests` list from each upstream `Makefrag` is parsed (rather than globbing) to honour upstream's own selection.
- **`sw/riscvTests/patches/move-fcsr-wpri.patch`** — masks Spatz's non-standard `fmode` bits (`fcsr[9:8]`) in upstream `move.S`, which otherwise leak into the WPRI region the test reads back.
- **`sw/riscvTests/CMakeLists.txt`** — includes the above.
- Unimplemented capabilities are gated, not silently skipped: `fdiv`/`ma_data` are marked `WILL_FAIL` behind `RVTESTS_HAS_DIVSQRT` / `RVTESTS_HAS_MISALIGNED` (both `OFF` by default), so they build and run but don't red the suite.

## Baseline on current `main`

`63/71 pass`. The 8 failures are all **real scalar-FP bugs** in `main`, which this harness now surfaces:

| Failing test (case) | Bug | Fix |
|---|---|---|
| `rv32ud-p-ldst` (6) | `flw` not NaN-boxed | #109 |
| `rv32uf-p-fclass` (2), `rv32uf/ud-p-fcmp` (10) | unboxed narrow FP operand misread | #109 |
| `rv32uf/ud-p-fcvt_w` (2) | scalar `fcvt.w.d/s` INT width | #110 |
| `rv32ud-p-fcvt` (5), `rv32ud-p-fmadd` (2) | fp32→fp64 special widening / FP64 `rs3` width | — |

With the corresponding FP fixes applied, the suite goes **71/71** (verified locally). Landing this harness first gives those fix PRs a concrete regression target.

## Notes

- `fdiv` stays `WILL_FAIL` until scalar HW divsqrt lands; flip `RVTESTS_HAS_DIVSQRT=ON` then.
- Self-contained: no changes to RTL or runtime.
