### PR TITLE
[Hot Fix] RISCV-OPCODES: Switch to a temp folk for old opcodes version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ sw/toolchain/llvm-project: sw/toolchain/llvm-project.version
 
 sw/toolchain/riscv-opcodes: sw/toolchain/riscv-opcodes.version
 	mkdir -p sw/toolchain
-	cd sw/toolchain && git clone https://github.com/pulp-platform/riscv-opcodes.git
+	cd sw/toolchain && git clone https://github.com/DiyouS/riscv-opcodes.git
 	cd sw/toolchain/riscv-opcodes &&                 \
 		git checkout `cat ../riscv-opcodes.version` && \
 		git submodule update --init --recursive --jobs=8 .


### PR DESCRIPTION
This is a temporary solution. We need to merge the Spatz-related changes into the latest opcode version.