### PR TITLE
Merge, saturated add and sub, integer comparison instructions added, bugs with masks fixed

### DIFF
--- a/hw/ip/snitch/src/snitch.sv
+++ b/hw/ip/snitch/src/snitch.sv
@@ -2506,6 +2506,12 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       riscv_instr::VWADDU_VV,
       riscv_instr::VWSUB_VV,
       riscv_instr::VWSUBU_VV,
+      riscv_instr::VSADD_VV,
+      riscv_instr::VSADD_VI,
+      riscv_instr::VSADDU_VV,
+      riscv_instr::VSADDU_VI,
+      riscv_instr::VSSUB_VV,
+      riscv_instr::VSSUBU_VV,
       riscv_instr::VAND_VV,
       riscv_instr::VAND_VI,
       riscv_instr::VOR_VV,
@@ -2579,6 +2585,8 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       riscv_instr::VWMACCSU_VV,
       riscv_instr::VMV_V_V,
       riscv_instr::VMV_V_I,
+      riscv_instr::VMERGE_VVM,
+      riscv_instr::VMERGE_VIM,
       riscv_instr::VFMV_F_S,
       riscv_instr::VSLIDEUP_VI,
       riscv_instr::VSLIDEDOWN_VI: begin
@@ -2655,6 +2663,10 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       riscv_instr::VWADDU_VX,
       riscv_instr::VWSUB_VX,
       riscv_instr::VWSUBU_VX,
+      riscv_instr::VSADD_VX,
+      riscv_instr::VSADDU_VX,
+      riscv_instr::VSSUB_VX,
+      riscv_instr::VSSUBU_VX,
       riscv_instr::VAND_VX,
       riscv_instr::VOR_VX,
       riscv_instr::VXOR_VX,
@@ -2700,6 +2712,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
       riscv_instr::VWMACCUS_VX,
       riscv_instr::VMV_V_X,
       riscv_instr::VMV_S_X,
+      riscv_instr::VMERGE_VXM,
       riscv_instr::VSLIDEUP_VX,
       riscv_instr::VSLIDEDOWN_VX,
       riscv_instr::VSLIDE1UP_VX,
@@ -2762,7 +2775,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
           illegal_inst = 1'b1;
         end
       end
-`ifdef VENTAGLIO
+
       riscv_instr::VFXMACC_VRF,
       riscv_instr::VFXMUL_VRF,
       riscv_instr::VVENTCLR: begin
@@ -2775,7 +2788,7 @@ module snitch import snitch_pkg::*; import riscv_instr::*; #(
           illegal_inst = 1'b1;
         end
       end
-`endif
+
       riscv_instr::VLE8_V,
       riscv_instr::VLE16_V,
       riscv_instr::VLE32_V,

--- a/hw/ip/spatz/src/generated/spatz_pkg.sv
+++ b/hw/ip/spatz/src/generated/spatz_pkg.sv
@@ -118,7 +118,7 @@ package spatz_pkg;
   // Vector operations
   typedef enum logic [6:0] {
     // Arithmetic and logic instructions
-    VADD, VSUB, VADC, VSBC, VRSUB, VMINU, VMIN, VMAXU, VMAX, VAND, VOR, VXOR,
+    VADD, VSUB, VADC, VSBC, VRSUB, VMINU, VMIN, VMAXU, VMAX, VAND, VOR, VXOR, VSADD, VSADDU, VSSUB, VSSUBU,
     // Shifts,
     VSLL, VSRL, VSRA, VNSRL, VNSRA,
     // Merge and Move

--- a/hw/ip/spatz/src/spatz_controller.sv
+++ b/hw/ip/spatz/src/spatz_controller.sv
@@ -759,6 +759,12 @@ module spatz_controller
             spatz_req.vstart = '0;
           end
 
+          if (spatz_req.op inside {VMAND, VMANDNOT, VMOR, VMXOR,
+                                   VMORNOT, VMNAND, VMNOR, VMXNOR}) begin
+            spatz_req.vl     = (vl_q + (8 << int'(spatz_req.vtype.vsew)) - 1) >> (int'(spatz_req.vtype.vsew) + 3);
+            spatz_req.vstart = '0;
+          end
+
 `ifdef VENTAGLIO
           // Is this a VTL related instruction?
           if (spatz_req.op_vtl.use_vtl) begin

--- a/hw/ip/spatz/src/spatz_decoder.sv
+++ b/hw/ip/spatz/src/spatz_decoder.sv
@@ -267,6 +267,16 @@ module spatz_decoder
         riscv_instr::VWSUB_VX,
         riscv_instr::VWSUBU_VV,
         riscv_instr::VWSUBU_VX,
+        riscv_instr::VSADD_VV,
+        riscv_instr::VSADD_VX,
+        riscv_instr::VSADD_VI,
+        riscv_instr::VSADDU_VV,
+        riscv_instr::VSADDU_VX,
+        riscv_instr::VSADDU_VI,
+        riscv_instr::VSSUB_VV,
+        riscv_instr::VSSUB_VX,
+        riscv_instr::VSSUBU_VV,
+        riscv_instr::VSSUBU_VX,
         riscv_instr::VAND_VV,
         riscv_instr::VAND_VX,
         riscv_instr::VAND_VI,
@@ -475,6 +485,28 @@ module spatz_decoder
               spatz_req.op                 = VSUB;
               spatz_req.op_arith.widen_vs1 = 1'b1;
               spatz_req.op_arith.widen_vs2 = 1'b1;
+            end
+
+            riscv_instr::VSADD_VV,
+            riscv_instr::VSADD_VX,
+            riscv_instr::VSADD_VI: begin
+              spatz_req.op = VSADD;
+            end
+
+            riscv_instr::VSADDU_VV,
+            riscv_instr::VSADDU_VX,
+            riscv_instr::VSADDU_VI: begin
+              spatz_req.op = VSADDU;
+            end
+
+            riscv_instr::VSSUB_VV,
+            riscv_instr::VSSUB_VX: begin
+              spatz_req.op = VSSUB;
+            end
+
+            riscv_instr::VSSUBU_VV,
+            riscv_instr::VSSUBU_VX: begin
+              spatz_req.op = VSSUBU;
             end
 
             // Vector Logic

--- a/hw/ip/spatz/src/spatz_ipu.sv
+++ b/hw/ip/spatz/src/spatz_ipu.sv
@@ -80,7 +80,7 @@ module spatz_ipu import spatz_pkg::*; import rvv_pkg::vew_e; #(
 
     // Is the operation signed?
     logic is_signed_d;
-    assign is_signed_d = operation_i inside {VMIN, VMAX, VMULH, VMULHSU, VDIV, VREM};
+    assign is_signed_d = operation_i inside {VMIN, VMAX, VMULH, VMULHSU, VDIV, VREM, VMSGT, VMSLE, VMSLT, VSADD, VSSUB};
     `FFL(is_signed, is_signed_d, operation_valid_i && operation_ready_o, 1'b0)
 
     // Is the operation signed and is this a VMULHSU?
@@ -100,7 +100,7 @@ module spatz_ipu import spatz_pkg::*; import rvv_pkg::vew_e; #(
     assign sew   = sew_i;
 
     // Is the operation signed?
-    assign is_signed = operation inside {VMIN, VMAX, VMULH, VMULHSU, VDIV, VREM};
+    assign is_signed = operation inside {VMIN, VMAX, VMULH, VMULHSU, VDIV, VREM, VMSGT, VMSLE, VMSLT, VSADD, VSSUB};
 
     // Is the operation signed and is this a VMULHSU?
     assign is_signed_and_not_vmulhsu = is_signed && (operation != VMULHSU);

--- a/hw/ip/spatz/src/spatz_pkg.sv.tpl
+++ b/hw/ip/spatz/src/spatz_pkg.sv.tpl
@@ -143,7 +143,7 @@ package spatz_pkg;
   // Vector operations
   typedef enum logic [6:0] {
     // Arithmetic and logic instructions
-    VADD, VSUB, VADC, VSBC, VRSUB, VMINU, VMIN, VMAXU, VMAX, VAND, VOR, VXOR,
+    VADD, VSUB, VADC, VSBC, VRSUB, VMINU, VMIN, VMAXU, VMAX, VAND, VOR, VXOR, VSADD, VSADDU, VSSUB, VSSUBU,
     // Shifts,
     VSLL, VSRL, VSRA, VNSRL, VNSRA,
     // Merge and Move

--- a/hw/ip/spatz/src/spatz_simd_lane.sv
+++ b/hw/ip/spatz/src/spatz_simd_lane.sv
@@ -218,6 +218,48 @@ module spatz_simd_lane import spatz_pkg::*; import rvv_pkg::vew_e; #(
       unique case (operation_i)
         VADD, VMACC, VMADD, VADC         : simd_result = adder_result[Width-1:0];
         VSUB, VRSUB, VNMSAC, VNMSUB, VSBC: simd_result = subtractor_result[Width-1:0];
+        VSADDU                           : begin
+          simd_result = adder_result[Width] ? '1 : adder_result[Width-1:0];
+          for (int i = 0; i < $clog2(Width/8); i++)
+            if (sew_i == rvv_pkg::vew_e'(i))
+              simd_result = adder_result[8*(2**i)] ? ((Width'(1) << (8*(2**i))) - Width'(1))
+                                                   : adder_result[Width-1:0];
+        end
+        VSADD                           : begin
+          simd_result = (arith_op1[Width-1] == arith_op2[Width-1]) &&
+                        (adder_result[Width-1] != arith_op1[Width-1])
+                      ? (arith_op1[Width-1] ? {1'b1, {Width-1{1'b0}}}
+                                            : {1'b0, {Width-1{1'b1}}})
+                      : adder_result[Width-1:0];
+          for (int i = 0; i < $clog2(Width/8); i++)
+            if (sew_i == rvv_pkg::vew_e'(i))
+              simd_result = (arith_op1[8*(2**i)-1] == arith_op2[8*(2**i)-1]) &&
+                            (adder_result[8*(2**i)-1] != arith_op1[8*(2**i)-1])
+                          ? (arith_op1[8*(2**i)-1] ? ( Width'(1) << (8*(2**i)-1))
+                                                   : ((Width'(1) << (8*(2**i)-1)) - Width'(1)))
+                          : adder_result[Width-1:0];
+        end
+        VSSUBU: begin
+          simd_result = subtractor_result[Width] ? '0 : subtractor_result[Width-1:0];
+          for (int i = 0; i < $clog2(Width/8); i++)
+            if (sew_i == rvv_pkg::vew_e'(i))
+              simd_result = subtractor_result[8*(2**i)] ? '0
+                                                        : subtractor_result[Width-1:0];
+        end
+        VSSUB: begin
+          simd_result = (arith_op2[Width-1] != arith_op1[Width-1]) &&
+                        (subtractor_result[Width-1] != arith_op2[Width-1])
+                      ? (arith_op2[Width-1] ? {1'b1, {Width-1{1'b0}}}     // MIN
+                                            : {1'b0, {Width-1{1'b1}}})    // MAX
+                      : subtractor_result[Width-1:0];
+          for (int i = 0; i < $clog2(Width/8); i++)
+            if (sew_i == rvv_pkg::vew_e'(i))
+              simd_result = (arith_op2[8*(2**i)-1] != arith_op1[8*(2**i)-1]) &&
+                            (subtractor_result[8*(2**i)-1] != arith_op2[8*(2**i)-1])
+                          ? (arith_op2[8*(2**i)-1] ? ( Width'(1) << (8*(2**i)-1))
+                                                   : ((Width'(1) << (8*(2**i)-1)) - Width'(1)))
+                          : subtractor_result[Width-1:0];
+        end
         VMIN, VMINU                      : simd_result = $signed({op_s1_i[Width-1] & is_signed_i, op_s1_i}) <= $signed({op_s2_i[Width-1] & is_signed_i, op_s2_i}) ? op_s1_i : op_s2_i;
         VMAX, VMAXU                      : simd_result = $signed({op_s1_i[Width-1] & is_signed_i, op_s1_i}) > $signed({op_s2_i[Width-1] & is_signed_i, op_s2_i}) ? op_s1_i : op_s2_i;
         VAND, VMAND                      : simd_result = op_s1_i & op_s2_i;
@@ -231,6 +273,11 @@ module spatz_simd_lane import spatz_pkg::*; import rvv_pkg::vew_e; #(
         VSLL                             : simd_result = shift_operand << shift_amount;
         VSRL                             : simd_result = shift_operand >> shift_amount;
         VSRA                             : simd_result = $signed(shift_operand) >>> shift_amount;
+        VMSLT, VMSLTU                    : simd_result = Width'($signed({op_s2_i[Width-1] & is_signed_i, op_s2_i}) <  $signed({op_s1_i[Width-1] & is_signed_i, op_s1_i}));
+        VMSLE, VMSLEU                    : simd_result = Width'($signed({op_s2_i[Width-1] & is_signed_i, op_s2_i}) <= $signed({op_s1_i[Width-1] & is_signed_i, op_s1_i}));
+        VMSGT, VMSGTU                    : simd_result = Width'($signed({op_s2_i[Width-1] & is_signed_i, op_s2_i}) >  $signed({op_s1_i[Width-1] & is_signed_i, op_s1_i}));
+        VMSEQ                            : simd_result = Width'(op_s1_i == op_s2_i);
+        VMSNE                            : simd_result = Width'(op_s1_i != op_s2_i);
         // TODO: Change selection when SEW does not equal Width
         VMUL                             : simd_result = mult_result[Width-1:0];
         VMULH, VMULHU, VMULHSU           : begin
@@ -245,6 +292,7 @@ module spatz_simd_lane import spatz_pkg::*; import rvv_pkg::vew_e; #(
           simd_result    = div_result;
           result_valid_o = div_out_valid;
         end
+        VMERGE: simd_result = op_s1_i;
         default: simd_result = '0;
       endcase // operation_i
     end

--- a/hw/ip/spatz/src/spatz_vfu.sv
+++ b/hw/ip/spatz/src/spatz_vfu.sv
@@ -66,6 +66,13 @@ module spatz_vfu
 
     // Is this a reduction?
     logic reduction;
+    // Is this a comparison?
+    logic is_cmp;
+    vlen_t vl;
+    // Is this instruction unmasked?
+    logic vm;
+    // Is this merge instruction?
+    logic merge;
     // valid bytes in this VRF word
     logic [$clog2(VRFWordBWidth+1)-1:0] valid_bytes;
   } vfu_tag_t;
@@ -226,7 +233,8 @@ module spatz_vfu
   logic                  result_ready;
 
   // it represents the VRF word index
-  logic [$clog2(NrWordsPerVector):0] word_idx_d, word_idx_q;
+  // calculates word index in instruction, LMUL max = 8
+  logic [$clog2(NrWordsPerVector*8):0] word_idx_d, word_idx_q;
   `FF(word_idx_q, word_idx_d, '0)
 
   always_comb begin: control_proc
@@ -507,7 +515,7 @@ module spatz_vfu
   logic v0_t_is_ready;
   assign v0_t_is_ready   = (operand_state_q == READ_V0_t) && vrf_rvalid_i[0] && vrf_rvalid_i[1];
   logic v0_t_read_done;
-  `FFLARNC(v0_t_read_done,1'b1,v0_t_is_ready,vfu_rsp_valid_o,1'b0,clk_i,rst_ni);
+  `FFLARNC(v0_t_read_done,1'b1,v0_t_is_ready,last_request,1'b0,clk_i,rst_ni);
 
   logic switch_to_read_v0t;
   assign switch_to_read_v0t = (operand_state_q == READ_OPERANDS) && spatz_req_valid
@@ -528,6 +536,7 @@ module spatz_vfu
 
   vlen_t vl_q_plus_nr_elem_word;
   assign vl_q_plus_nr_elem_word = vl_q + nr_elem_word;
+  logic [VLEN-1:0] operand_v0_t_q;
 
   always_comb begin: operand_proc
     reduction_operand_v0_t_lo = '0;
@@ -571,6 +580,18 @@ module spatz_vfu
                 default: operand2 = {1*N_FU{spatz_req.rs2}};
               endcase
           end
+           if (spatz_req.op == VMERGE) begin
+            automatic logic [N_FU*ELEN-1:0] mmask;
+            mmask = '0;
+            unique case (spatz_req.vtype.vsew)
+              EW_8:  for (int e = 0; e < N_FU*ELENB;   e++) mmask[e*8  +: 8]  = {8 {operand_v0_t_q[vl_q + e]}};
+              EW_16: for (int e = 0; e < N_FU*ELENB/2; e++) mmask[e*16 +: 16] = {16{operand_v0_t_q[vl_q + e]}};
+              EW_32: for (int e = 0; e < N_FU*ELENB/4; e++) mmask[e*32 +: 32] = {32{operand_v0_t_q[vl_q + e]}};
+              default: if (MAXEW == EW_64)
+                     for (int e = 0; e < N_FU*ELENB/8; e++) mmask[e*64 +: 64] = {64{operand_v0_t_q[vl_q + e]}};
+            endcase
+            operand1 = (operand1 & mmask) | (operand2 & ~mmask);
+          end
       end
       READ_V0_t: begin
         operand_v0_t_lo = vrf_rdata_i[0];
@@ -590,7 +611,6 @@ module spatz_vfu
   `FFL(operand_v0_t_lo_q, operand_v0_t_lo, v0_t_is_ready, '0)
   `FFL(operand_v0_t_hi_q, operand_v0_t_hi, v0_t_is_ready, '0)
 
-  logic [VLEN-1:0] operand_v0_t_q;
   assign operand_v0_t_q = {operand_v0_t_hi_q,operand_v0_t_lo_q};
 
   ///////////////////////
@@ -784,7 +804,7 @@ module spatz_vfu
         word_issued = spatz_req_valid && &(in_ready | ~valid_operations) && operands_ready && !stall;
 
         // Are we ready to accept a result?
-        result_ready = &(result_valid | ~pending_results) && ((result_tag.wb && vfu_rsp_ready_i) || vrf_wvalid_i || (spatz_req.op == VFCMP && !result_tag.last));
+        result_ready = &(result_valid | ~pending_results) && ((result_tag.wb && vfu_rsp_ready_i) || vrf_wvalid_i || (result_tag.is_cmp && !result_tag.last));
 
         // Initialize the pointers
         reduction_pointer_d = '0;
@@ -1072,6 +1092,10 @@ module spatz_vfu
   vrf_addr_t [2:0] vreg_addr_q, vreg_addr_d;
   `FF(vreg_addr_q, vreg_addr_d, '0)
 
+  // The signal to choose comparison instructions  
+  logic is_cmp_req;
+  assign is_cmp_req = (spatz_req.op == VFCMP) || spatz_req.op inside {VMSEQ, VMSNE, VMSLT, VMSLTU, VMSLE, VMSLEU, VMSGT, VMSGTU};
+
   // Calculate new vector register address
   always_comb begin : vreg_addr_proc
     vreg_addr_d = vreg_addr_q;
@@ -1090,6 +1114,10 @@ module spatz_vfu
       narrowing      : spatz_req.op_arith.is_narrowing,
       narrowing_upper: narrowing_upper_q,
       reduction      : spatz_req.op_arith.is_reduction,
+      is_cmp         : is_cmp_req,
+      vl             : spatz_req.vl,
+      vm             : spatz_req.op_arith.vm,
+      merge          : (spatz_req.op == VMERGE),
       valid_bytes    : valid_bytes_wr // count of the number of valid bytes in the VRF word (write side)
     };
 
@@ -1119,12 +1147,12 @@ module spatz_vfu
           if (word_issued) begin
             vreg_addr_d[0] = vreg_addr_d[0] + (!spatz_req.op_arith.widen_vs2 || widening_upper_q);
             vreg_addr_d[1] = vreg_addr_d[1] + (!spatz_req.op_arith.widen_vs1 || widening_upper_q);
-            vreg_addr_d[2] = vreg_addr_d[2] + (!spatz_req.op_arith.is_reduction && (!spatz_req.op_arith.is_narrowing || narrowing_upper_q) && (spatz_req.op != VFCMP));
+            vreg_addr_d[2] = vreg_addr_d[2] + (!spatz_req.op_arith.is_reduction && (!spatz_req.op_arith.is_narrowing || narrowing_upper_q) && !is_cmp_req);
           end
           end else if (spatz_req_valid && vl_q < spatz_req.vl && word_issued) begin
             vreg_addr_d[0] = vreg_addr_q[0] + (!spatz_req.op_arith.widen_vs2 || widening_upper_q);
             vreg_addr_d[1] = vreg_addr_q[1] + (!spatz_req.op_arith.widen_vs1 || widening_upper_q);
-            vreg_addr_d[2] = vreg_addr_q[2] + (!spatz_req.op_arith.is_reduction && (!spatz_req.op_arith.is_narrowing || narrowing_upper_q) && (spatz_req.op != VFCMP));
+            vreg_addr_d[2] = vreg_addr_q[2] + (!spatz_req.op_arith.is_reduction && (!spatz_req.op_arith.is_narrowing || narrowing_upper_q) && !is_cmp_req);
           end
         end
        end
@@ -1158,7 +1186,7 @@ module spatz_vfu
     // Got a new result
     if (&(result_valid | ~pending_results) && !result_tag.reduction) begin
       vreg_we  = !result_tag.wb;
-      if (spatz_req.op == VFCMP) begin
+      if (result_tag.is_cmp) begin
         vreg_we    = result_tag.last;
       end
     end
@@ -1175,7 +1203,7 @@ module spatz_vfu
  vew_e sew_wb;
  logic widening_wb;
  assign widening_wb = spatz_req.op_arith.widen_vs1 || spatz_req.op_arith.widen_vs2;
- assign sew_wb = vew_e'(int'(spatz_req.vtype.vsew) + widening_wb);
+ assign sew_wb = vew_e'(int'(result_tag.vsew) + widening_wb);
 
  vrf_be_t       vreg_wbe_pre;
  logic [VRFWordBWidth-1:0] tail_wbe_eff;
@@ -1200,17 +1228,17 @@ always_comb begin : vreg_wbe_proc
 
     if ((result_tag.last && &(result_valid | ~pending_results) && reduction_state_q inside {Reduction_NormalExecution, Reduction_Wait}) || reduction_done)
       vreg_wb_word_cnt_d = 0;
-    else if (&(result_valid | ~pending_results) && (!spatz_req.op_arith.is_narrowing || narrowing_upper_q))
+    else if (&(result_valid | ~pending_results) && (!result_tag.narrowing || result_tag.narrowing_upper))
       vreg_wb_word_cnt_d = vreg_wb_word_cnt_q + 1;
     // Got a new result
     if (&(result_valid | ~pending_results) && !result_tag.reduction) begin
       vreg_wbe = '1;
-      if (spatz_req.op == VFCMP) begin
+      if (result_tag.is_cmp) begin
         // every vector element requires 1 bit of wbe --> ceil(vl/8)
         automatic logic [$clog2((MAXVL+7)/8+1)-1:0] mask_bytes;
-        mask_bytes = (spatz_req.vl + 7) >> 3;
+        mask_bytes = (result_tag.vl + 7) >> 3;
         vreg_wbe   = (mask_bytes >= N_FU*ELENB) ? '1 : vrf_be_t'((vrf_be_t'(1) << mask_bytes) - 1);
-      end else if(!spatz_req.op_arith.vm && !spatz_req.op_arith.is_scalar && !result_tag.narrowing) begin //masking the wb results
+      end else if(!result_tag.vm && !result_tag.merge && !spatz_req.op_arith.is_scalar && !result_tag.narrowing) begin //masking the wb results
         unique case (sew_wb) // add widening support
           EW_8:for(int i=0;i<VRFWordBWidth;i=i+1)begin
             vreg_wbe[i*1+:1] = {1{operand_v0_t_q[vreg_wb_word_cnt_q * VRFWordBWidth + i]}};
@@ -1227,7 +1255,7 @@ always_comb begin : vreg_wbe_proc
         endcase
         vreg_wbe &= tail_wbe_eff; // tail-undisturbed + masking (v0.t)
       end else if(result_tag.narrowing) begin
-        if(!spatz_req.op_arith.vm && !spatz_req.op_arith.is_scalar) begin
+        if(!result_tag.vm && !spatz_req.op_arith.is_scalar) begin
           unique case (sew_wb)
             EW_16:for(int i=0;i<VRFWordBWidth/2;i=i+1)begin
               vreg_wbe_pre[i*2+:2] = {2{operand_v0_t_q[vreg_wb_word_cnt_q * (VRFWordBWidth/2) + i]}};
@@ -1263,11 +1291,11 @@ always_comb begin : vreg_wbe_proc
 end:vreg_wbe_proc
 
 logic vfcmp_result_accepted;
-assign vfcmp_result_accepted = (spatz_req.op == VFCMP) && &(result_valid | ~pending_results) && result_ready;
+assign vfcmp_result_accepted = result_tag.is_cmp && &(result_valid | ~pending_results) && result_ready;
 
   always_comb begin : VRF_cnt_proc
     word_idx_d = word_idx_q;
-    if (spatz_req.op != VFCMP)
+    if (!result_tag.is_cmp)
       word_idx_d = '0;
     else if (vfcmp_result_accepted) begin
       if (result_tag.last)
@@ -1297,32 +1325,32 @@ assign vfcmp_result_accepted = (spatz_req.op == VFCMP) && &(result_valid | ~pend
         default:;
       endcase
 
-    end else if (spatz_req.op == VFCMP) begin
+    end else if (result_tag.is_cmp) begin
       automatic logic v0_bit;
       vreg_wdata = '0;
 
-      unique case (spatz_req.vtype.vsew)
+      unique case (result_tag.vsew)
         EW_8: begin
           for (int i = 0; i < VRFWordWidth/8; i++) begin
-            v0_bit = (spatz_req.op_arith.vm) ? 1'b1 : operand_v0_t_q[i + (VRFWordWidth/8)*word_idx_q];
+            v0_bit = (result_tag.vm) ? 1'b1 : operand_v0_t_q[i + (VRFWordWidth/8)*word_idx_q];
             vreg_wdata[i + (VRFWordWidth/8)*word_idx_q] = result[i*8] & v0_bit;
           end
         end
         EW_16: begin
           for (int i = 0; i < VRFWordWidth/16; i++) begin
-            v0_bit = (spatz_req.op_arith.vm) ? 1'b1 : operand_v0_t_q[i + (VRFWordWidth/16)*word_idx_q];
+            v0_bit = (result_tag.vm) ? 1'b1 : operand_v0_t_q[i + (VRFWordWidth/16)*word_idx_q];
             vreg_wdata[i + (VRFWordWidth/16)*word_idx_q] = result[i*16] & v0_bit;
           end
         end
         EW_32: begin
           for (int i = 0; i < VRFWordWidth/32; i++) begin
-            v0_bit = (spatz_req.op_arith.vm) ? 1'b1 : operand_v0_t_q[i + (VRFWordWidth/32)*word_idx_q];
+            v0_bit = (result_tag.vm) ? 1'b1 : operand_v0_t_q[i + (VRFWordWidth/32)*word_idx_q];
             vreg_wdata[i + (VRFWordWidth/32)*word_idx_q] = result[i*32] & v0_bit;
           end
         end
         EW_64: begin
           for (int i = 0; i < VRFWordWidth/64; i++) begin
-            v0_bit = (spatz_req.op_arith.vm) ? 1'b1 : operand_v0_t_q[i + (VRFWordWidth/64)*word_idx_q];
+            v0_bit = (result_tag.vm) ? 1'b1 : operand_v0_t_q[i + (VRFWordWidth/64)*word_idx_q];
             vreg_wdata[i + (VRFWordWidth/64)*word_idx_q] = result[i*64] & v0_bit;
           end
         end
@@ -1333,7 +1361,7 @@ assign vfcmp_result_accepted = (spatz_req.op == VFCMP) && &(result_valid | ~pend
 
   always_comb begin : wdata_proc
     wdata_d = wdata_q;
-    if (spatz_req.op != VFCMP) begin
+    if (!result_tag.is_cmp) begin
       wdata_d = '0;
     end else if (vfcmp_result_accepted) begin
       if (result_tag.last)
@@ -1349,7 +1377,7 @@ assign vfcmp_result_accepted = (spatz_req.op == VFCMP) && &(result_valid | ~pend
   assign vrf_re_o    = vreg_r_req;
   assign vrf_we_o    = vreg_we;
   assign vrf_wbe_o   = vreg_wbe;
-  assign vrf_wdata_o = (spatz_req.op == VFCMP) ? (wdata_q | vreg_wdata) : vreg_wdata;
+  assign vrf_wdata_o = result_tag.is_cmp ? (wdata_q | vreg_wdata) : vreg_wdata;
   assign vrf_id_o    = {result_tag.id, {3{spatz_req.id}}};
 
   //////////


### PR DESCRIPTION
- Add support for the MERGE instruction (vmerge).

- Add support for integer comparison instructions from RVV (vmseq, vmsne, vmslt[u], vmsle[u], vmsgt[u]).

- Add the corresponding fields to the VFU instruction tag (is_cmp, vl, vm, merge).

- Add support for saturating integer instructions from RVV: vsadd, vsaddu, vssub, vssubu.

- Mask-logical instructions (vmand, vmor, vmxor, vmnand, vmnor, vmxnor, vmandnot, vmornot): vl is recomputed so the datapath processes exactly ceil(vl_elements / 8) bytes of mask - one bit per element - instead of a full SEW-width element per mask bit.

- Fix several places where the result must be computed from result_tag rather than from spatz_req. Because the request can relate to a new instruction already. Using spatz_req there could apply the wrong instruction's attributes to an earlier result.

- v0_t_read_done signal now goes low after reading the last input. Dependence of vfu_rsp_valid_o triggered a bug in case of sequential masked instructions; the second instruction could not start to read v0 because it was still high. 

TODO: fix writing the result mask for FP and INT comparison instructions. (Now it is writing one word, which doesn't allow writing the full max for vector in case of m8)