### PR TITLE
hw: Add missing TCDM misalign in Carfield cfg

### DIFF
--- a/hw/system/spatz_cluster/cfg/spatz_cluster.carfield.l2.hjson
+++ b/hw/system/spatz_cluster/cfg/spatz_cluster.carfield.l2.hjson
@@ -21,7 +21,8 @@
         "axi_isolate_enable": true,
         "tcdm": {
             "size": 128,
-            "banks": 16
+            "banks": 16,
+            "misalign": false
         },
         "cluster_periph_size": 64, // kB
         "dma_data_width": 64,


### PR DESCRIPTION
The following commit https://github.com/pulp-platform/spatz/commit/688f4d70726763e2ca768c85bc5af10b072ca09e added the required TCDM misalign keyword to all configs except spatz_cluster.carfield.l2.
