### PR TITLE
hw: fix metadata used for commit

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -133,7 +133,7 @@ packages:
     - riscv-dbg
     - tech_cells_generic
   spatz_vpu:
-    revision: 1cadb8016e51f95b7c1e07b0f608cebbf96d81aa
+    revision: 1705213d6aab58c82391243211df0a8a440f8138
     version: null
     source:
       Git: https://github.com/pulp-platform/spatz_vpu.git


### PR DESCRIPTION
Fix metadata used for commit, specifically: is_cmp - comparison flag, is_merge - merge flag (merge instruction will be added in the following commit), vl and vm.