### PR TITLE
Ihor/fix controller

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -133,7 +133,7 @@ packages:
     - riscv-dbg
     - tech_cells_generic
   spatz_vpu:
-    revision: 1705213d6aab58c82391243211df0a8a440f8138
+    revision: 34c2ee399cf4122fe30fc52e4b987df92c949b22
     version: null
     source:
       Git: https://github.com/pulp-platform/spatz_vpu.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -133,7 +133,7 @@ packages:
     - riscv-dbg
     - tech_cells_generic
   spatz_vpu:
-    revision: 34c2ee399cf4122fe30fc52e4b987df92c949b22
+    revision: 7238180b8f9032647b18277708d519d3f532c3cb
     version: null
     source:
       Git: https://github.com/pulp-platform/spatz_vpu.git

--- a/sw/riscvTests/isa/rv64uv/vmand.c
+++ b/sw/riscvTests/isa/rv64uv/vmand.c
@@ -65,15 +65,25 @@ void TEST_CASE6() {
 }
 
 void TEST_CASE7() {
-  VSET(2, e8, m1);
-  VLOAD_8(v9, 0x5A, 0x5A);
+  uint8_t *buf  = (uint8_t *)snrt_l1alloc(64 * sizeof(uint8_t));
+  uint8_t *gold = (uint8_t *)snrt_l1alloc(64 * sizeof(uint8_t));
+  printf("[TC 7] \n");
+  VSET(64, e8, m1);
+  asm volatile("vmv.v.x v9, %0" :: "r"(0xBB));
+  asm volatile("vmv.v.x v8, %0" :: "r"(0x77));
   VSET(128, e8, m4);
   asm volatile("vmv.v.x v4,  %0" :: "r"(0xCD));
   asm volatile("vmv.v.x v12, %0" :: "r"(0x84));
   asm volatile("vmand.mm v8, v4, v12");
-  VSET(2, e8, m1);
-  VCMP_U8(7, v8, 0x84, 0x84);
-  VCMP_U8(7, v9, 0x5A, 0x5A);
+  memset(gold, 0x84, 16);
+  memset(gold + 16, 0x77, 48);
+  VSET(64, e8, m1);
+  asm volatile("vse8.v v8, (%0)" :: "r"(buf) : "memory");
+  VMCMP(uint8_t, "%hhu", 7, buf, gold, 64);
+  memset(gold, 0xBB, 64);
+  VSET(64, e8, m1);
+  asm volatile("vse8.v v9, (%0)" :: "r"(buf) : "memory");
+  VMCMP(uint8_t, "%hhu", 7, buf, gold, 64);
 }
 
 int main(void) {

--- a/sw/riscvTests/isa/rv64uv/vmand.c
+++ b/sw/riscvTests/isa/rv64uv/vmand.c
@@ -65,25 +65,16 @@ void TEST_CASE6() {
 }
 
 void TEST_CASE7() {
-  uint8_t *buf  = (uint8_t *)snrt_l1alloc(64 * sizeof(uint8_t));
-  uint8_t *gold = (uint8_t *)snrt_l1alloc(64 * sizeof(uint8_t));
-  printf("[TC 7] \n");
   VSET(64, e8, m1);
-  asm volatile("vmv.v.x v9, %0" :: "r"(0xBB));
-  asm volatile("vmv.v.x v8, %0" :: "r"(0x77));
+  asm volatile("vmv.v.x v8, %0" :: "r"(0xBB));
   VSET(128, e8, m4);
   asm volatile("vmv.v.x v4,  %0" :: "r"(0xCD));
   asm volatile("vmv.v.x v12, %0" :: "r"(0x84));
   asm volatile("vmand.mm v8, v4, v12");
-  memset(gold, 0x84, 16);
-  memset(gold + 16, 0x77, 48);
-  VSET(64, e8, m1);
-  asm volatile("vse8.v v8, (%0)" :: "r"(buf) : "memory");
-  VMCMP(uint8_t, "%hhu", 7, buf, gold, 64);
-  memset(gold, 0xBB, 64);
-  VSET(64, e8, m1);
-  asm volatile("vse8.v v9, (%0)" :: "r"(buf) : "memory");
-  VMCMP(uint8_t, "%hhu", 7, buf, gold, 64);
+  VSET(4, e64, m1);
+  VCMP_U64(7, v8,
+    0x8484848484848484UL, 0x8484848484848484UL,
+    0xBBBBBBBBBBBBBBBBUL, 0xBBBBBBBBBBBBBBBBUL);
 }
 
 int main(void) {

--- a/sw/riscvTests/isa/rv64uv/vmand.c
+++ b/sw/riscvTests/isa/rv64uv/vmand.c
@@ -64,6 +64,18 @@ void TEST_CASE6() {
   VCMP_U8(6, v2, 0, 0, 0, 0, 0, 0, 0, 0);
 }
 
+void TEST_CASE7() {
+  VSET(2, e8, m1);
+  VLOAD_8(v9, 0x5A, 0x5A);
+  VSET(128, e8, m4);
+  asm volatile("vmv.v.x v4,  %0" :: "r"(0xCD));
+  asm volatile("vmv.v.x v12, %0" :: "r"(0x84));
+  asm volatile("vmand.mm v8, v4, v12");
+  VSET(2, e8, m1);
+  VCMP_U8(7, v8, 0x84, 0x84);
+  VCMP_U8(7, v9, 0x5A, 0x5A);
+}
+
 int main(void) {
   INIT_CHECK();
   enable_vec();
@@ -74,6 +86,7 @@ int main(void) {
   TEST_CASE4();
   TEST_CASE5();
   TEST_CASE6();
+  TEST_CASE7();
 
   EXIT_CHECK();
 }

--- a/sw/riscvTests/isa/rv64uv/vmand.c
+++ b/sw/riscvTests/isa/rv64uv/vmand.c
@@ -71,10 +71,10 @@ void TEST_CASE7() {
   asm volatile("vmv.v.x v4,  %0" :: "r"(0xCD));
   asm volatile("vmv.v.x v12, %0" :: "r"(0x84));
   asm volatile("vmand.mm v8, v4, v12");
-  VSET(4, e64, m1);
-  VCMP_U64(7, v8,
-    0x8484848484848484UL, 0x8484848484848484UL,
-    0xBBBBBBBBBBBBBBBBUL, 0xBBBBBBBBBBBBBBBBUL);
+  VSET(8, e32, m1);
+  VCMP_U32(7, v8,
+    0x84848484U, 0x84848484U, 0x84848484U, 0x84848484U,
+    0xBBBBBBBBU, 0xBBBBBBBBU, 0xBBBBBBBBU, 0xBBBBBBBBU);
 }
 
 int main(void) {


### PR DESCRIPTION
Fix vl computation for Vector Mask-Register Logical Instructions

Mask operations store 1 bit per element, but the datapath processes SEW-wide elements. For mask-register instructions, a conversion is needed to compute the number of SEW-wide elements holding the mask:
vl = ceil(vl_q / SEW)
Implemented as (vl_q + SEW - 1) >> log2(SEW), where SEW = 8<<vsew and log2(SEW) = vsew + 3, vl_q holds the number of elements to be processed.
Also force vstart = 0. After packing mask bits into SEW-wide words, the original element-indexed vstart no longer maps 1:1 to word indices.

Also, add a test checking this case.