### PR TITLE
Ihor/fix vfu2

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -133,7 +133,7 @@ packages:
     - riscv-dbg
     - tech_cells_generic
   spatz_vpu:
-    revision: 7238180b8f9032647b18277708d519d3f532c3cb
+    revision: da557fa540a996b84118cd95bfda126d63af5f68
     version: null
     source:
       Git: https://github.com/pulp-platform/spatz_vpu.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -133,7 +133,7 @@ packages:
     - riscv-dbg
     - tech_cells_generic
   spatz_vpu:
-    revision: da557fa540a996b84118cd95bfda126d63af5f68
+    revision: 235c830982391ced0b63baa42915eba711b703fb
     version: null
     source:
       Git: https://github.com/pulp-platform/spatz_vpu.git

--- a/sw/riscvTests/isa/rv64uv/vmfeq.c
+++ b/sw/riscvTests/isa/rv64uv/vmfeq.c
@@ -461,6 +461,26 @@ void TEST_CASE7(void) {
   CHECK_FFLAGS(NV);
 };
 
+void TEST_CASE8(void) {
+  uint32_t vlenb;
+  asm volatile("csrr %0, vlenb" : "=r"(vlenb));
+  VSET(128, e32, m8);
+  VCLEAR(v1);
+  asm volatile("vmv.v.x v8,  %0" :: "r"(0x40490fdb));
+  asm volatile("vmv.v.x v16, %0" :: "r"(0x40490fdb));
+  asm volatile("vmfeq.vv v1, v8, v16");
+  if (vlenb == 64) {
+    VSET(16, e8, m1);
+    VCMP_U8(23, v1,
+      0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+      0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF);
+  } else if (vlenb == 32) {
+    VSET(8, e8, m1);
+    VCMP_U8(23, v1,
+      0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF);
+  }
+}
+
 int main(void) {
   INIT_CHECK();
   enable_vec();
@@ -476,6 +496,7 @@ int main(void) {
 #endif
   TEST_CASE6();
   TEST_CASE7();
+  TEST_CASE8();
 
   EXIT_CHECK();
 }


### PR DESCRIPTION
The word index counter in the VFCMP result path was too narrow, causing it to overflow when iterating over a full m8 register group. The counter width is now set to $clog2(NrWordsPerVector*8)+1 to account for the maximum LMUL of 8.