### PR TITLE
Fix scalar ops

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -133,7 +133,7 @@ packages:
     - riscv-dbg
     - tech_cells_generic
   spatz_vpu:
-    revision: 045f8ff332c38fe452eda5aa64d6b642fd4657d1
+    revision: dbd1da34acf489f72017ac8f880a763fea2f1451
     version: null
     source:
       Git: https://github.com/pulp-platform/spatz_vpu.git

--- a/sw/riscvTests/CMakeLists.txt
+++ b/sw/riscvTests/CMakeLists.txt
@@ -185,4 +185,4 @@ add_snitch_test(vse64 isa/rv64uv/vse64.c)
 add_snitch_test(vss isa/rv64uv/vss.c)
 
 add_snitch_test(vill isa/rv64uv/vill.c)
-set_property(TEST ${SNITCH_TEST_PREFIX}rtl-invalid PROPERTY WILL_FAIL TRUE)
+set_property(TEST ${SNITCH_TEST_PREFIX}rtl-vill PROPERTY WILL_FAIL TRUE)

--- a/sw/riscvTests/CMakeLists.txt
+++ b/sw/riscvTests/CMakeLists.txt
@@ -186,3 +186,5 @@ add_snitch_test(vss isa/rv64uv/vss.c)
 
 add_snitch_test(vill isa/rv64uv/vill.c)
 set_property(TEST ${SNITCH_TEST_PREFIX}rtl-vill PROPERTY WILL_FAIL TRUE)
+
+add_snitch_test(scalar isa/rv64uv/scalar.c)

--- a/sw/riscvTests/isa/rv64uv/scalar.c
+++ b/sw/riscvTests/isa/rv64uv/scalar.c
@@ -1,0 +1,24 @@
+#include "vector_macros.h"
+
+int main(void) {
+
+  // ensure illegal vtype
+  unsigned int vlmul = 5;
+  unsigned int vsew  = 3;
+  unsigned int vtype = vsew << 3 | vlmul;
+
+  __asm__ volatile (
+      "li      t0, -1 \n"
+      "vsetvl zero, zero, %[vtype] \n":: [vtype]"r"(vtype):
+  );
+
+  asm volatile("mul a0, a1, a2");
+  asm volatile("add a0, a1, a2");
+  asm volatile("div a0, a1, a2");
+  asm volatile("fmul.b f0, f1, f2");
+  asm volatile("fmul.h f0, f1, f2");
+  asm volatile("fmul.s f0, f1, f2");
+  asm volatile("fmul.d f0, f1, f2");
+
+  return 0;
+}

--- a/sw/riscvTests/isa/rv64uv/vill.c
+++ b/sw/riscvTests/isa/rv64uv/vill.c
@@ -1,12 +1,13 @@
 #include "vector_macros.h"
 
 int main(void) {
-
-  unsigned int vtype = 1 << 31;
+  unsigned int vlmul = 5;
+  unsigned int vsew  = 3;
+  unsigned int vtype = vsew << 3 | vlmul;
 
   __asm__ volatile (
       "li      t0, -1 \n"
-      "vsetvl zero, zero, t0 \n"
+      "vsetvl zero, zero, %[vtype] \n":: [vtype]"r"(vtype):
   );
 
   asm volatile("vadd.vv v24, v8, v16");

--- a/sw/riscvTests/isa/rv64uv/vill.c
+++ b/sw/riscvTests/isa/rv64uv/vill.c
@@ -1,13 +1,9 @@
 #include "vector_macros.h"
 
 int main(void) {
-  unsigned int vlmul = 5;
-  unsigned int vsew  = 3;
-  unsigned int vtype = vsew << 3 | vlmul;
 
   __asm__ volatile (
-      "li      t0, -1 \n"
-      "vsetvl zero, zero, %[vtype] \n":: [vtype]"r"(vtype):
+      "vsetvli zero, zero, e64, mf8, ta, ma\n"
   );
 
   asm volatile("vadd.vv v24, v8, v16");


### PR DESCRIPTION
Follow-on PR from https://github.com/pulp-platform/spatz_vpu/pull/9, bumps the VPU version and adds tests.
`fdiv` I left commented out as that does not seem to be implemented.

Also: the `vill` test that was marked for failing marked the wrong test (`-illegal` instead of `-vill`), and it passed instead of failing. Update the test so that the `vill` flag is actually set.