### PR TITLE
fix(vrf_ecc): remove VLSU_VD_WD1 from VFU write-conflict check to bre…

### DIFF
--- a/hw/ip/spatz/src/spatz_vrf_ecc.sv
+++ b/hw/ip/spatz/src/spatz_vrf_ecc.sv
@@ -117,7 +117,7 @@ module spatz_vrf_ecc
     for (int unsigned bank = 0; bank < NrVRFBanks; bank++) begin
 `ifdef BUF_FPU
 `ifdef DOUBLE_BW
-      automatic logic write_request_vlsu = write_request[bank][VLSU_VD_WD0] | write_request[bank][VLSU_VD_WD1];
+      automatic logic write_request_vlsu = write_request[bank][VLSU_VD_WD0];
 `else
       automatic logic write_request_vlsu = write_request[bank][VLSU_VD_WD];
 `endif


### PR DESCRIPTION
Remove VLSU_VD_WD1 from VFU write-conflict check to break comb loop.