### PR TITLE
rtl: Add gzip-compressed and disabled traces support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ obj_dir/*
 *.dasm
 build/
 trace_*
+# ...but the tracer sources are not generated artefacts.
+!hw/ip/snitch/include/snitch/trace_writer.svh
+!hw/ip/snitch_test/src/trace_dpi.c
 mems
 *log
 .bender

--- a/README.md
+++ b/README.md
@@ -74,6 +74,69 @@ make annotate
 make help
 ```
 
+#### Instruction traces
+
+Pick the trace sink when building the RTL with `RTL_TRACE` (not to be confused
+with `TRACE`, which controls snRuntime software tracing):
+
+| | Output | Notes |
+|---|---|---|
+| `RTL_TRACE=plain` | `bin/logs/trace_hart_X.dasm` | default |
+| `RTL_TRACE=gz` | `bin/logs/trace_hart_X.dasm.gz` | ~32x smaller, and faster than `plain` |
+| `RTL_TRACE=off` | none | no tracer instantiated |
+
+```bash
+make bin/spatz_cluster.vsim RTL_TRACE=gz
+```
+
+`make traces` and `make annotate` accept either extension. To read a compressed
+trace yourself, `gzip -dc` it; in Python, `gzip.open(path, 'rt')`.
+
+With an `RTL_TRACE=gz` build, the backend can be changed per run without
+rebuilding, and the file extension follows it:
+
+```bash
+bin/spatz_cluster.vsim +trace_mode=thr:gz1 path/to/binary   # faster, larger
+bin/spatz_cluster.vsim +trace_mode=plain   path/to/binary   # writes .dasm
+bin/spatz_cluster.vsim +trace_mode=null    path/to/binary   # discard
+TW_MODE=thr:gz1 bin/spatz_cluster.vsim path/to/binary       # same, via env
+```
+
+| Mode | Effect |
+|---|---|
+| `thr:gz<1-9>` | worker thread deflates; **default is `thr:gz6`** |
+| `thr:plain` | worker thread, no compression |
+| `gz<1-9>` | deflate inline on the simulator thread — stalls it, avoid |
+| `plain` | plain `fwrite` |
+| `null` | discard |
+
+Environment knobs: `TW_MODE` (backend, overrides `+trace_mode`), `TW_BLKSZ` and
+`TW_NBLK` (handoff ring, default 256 KiB x 4 = 1 MiB per traced hart), `TW_LAT=1`
+(print per-write latency percentiles at exit).
+
+The defaults are sized for a real simulation and rarely need changing: an RTL
+sim emits only ~2 MB/s of trace per hart, some 50x below what the writer can
+absorb, so the tracer costs about 0.03% of run time either way. Tune only if you
+are memory-constrained or care about what a crash loses.
+
+| | Default | What it controls |
+|---|---|---|
+| `TW_BLKSZ` | 256 KiB | Handoff efficiency. **Do not shrink** - at 32 KiB the mean per-write cost goes from 9 ns to 1334 ns, worse than plain `$fwrite`. |
+| `TW_NBLK` | 2 | Burst headroom, 512 KiB/hart. Real traces measure no worse at 2 than at 4; raise it only if a workload traces in large bursts. |
+| `TW_GZBUF` | 64 KiB | How much trace a crash loses. No measurable cost at any size. |
+| `TW_MODE` | `thr:gz6` | Backend, same values as `+trace_mode`. |
+| `TW_LAT` | off | `=1` prints per-write latency percentiles at exit. |
+
+If memory is tight the lever is `TW_NBLK`, never a smaller `TW_BLKSZ`.
+
+**Crash behaviour.** If the simulator is killed, the `.gz` is still readable -
+`gzip -dc` reports "unexpected end of file", exits non-zero, and prints
+everything up to the cut. Every complete line before that point is intact and in
+order; only the final line is cut mid-way. Measured at the real trace rate, a
+`SIGKILL` loses ~900 KB with `thr:gz6` against ~690 KB for plain `$fwrite`,
+which buffers too. `TW_GZBUF` is the only knob that moves this - the ring does
+not, since it stays nearly empty at realistic rates.
+
 ### Configure the Cluster
 
 To configure the cluster with a different configuration, either edit the configuration files in the `cfg` folder or create a new configuration file and pass it to the Makefile:

--- a/hw/ip/snitch/include/snitch/trace_writer.svh
+++ b/hw/ip/snitch/include/snitch/trace_writer.svh
@@ -1,0 +1,63 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Compile-time selection of the instruction-trace sink.
+//
+//   (neither define)       $fopen/$fwrite/$fclose into a plain .dasm file.
+//   SNITCH_TRACE_GZ        DPI-C writer (hw/ip/snitch_test/src/trace_dpi.c)
+//                          producing a gzip stream, .dasm.gz. The default
+//                          backend is "thr:gz6": a worker thread deflates so
+//                          the simulator thread only memcpys into a block.
+//                          Override at run time with +trace_mode=<mode>.
+//   SNITCH_TRACE_DISABLE   no tracer instantiated at all; takes precedence.
+//
+// The macros keep both cores' tracers on one code path. A core declares the
+// DPI imports once with `SNITCH_TRACE_DECLS, then uses OPEN/WRITE/CLOSE.
+// OPEN builds the file name itself so the extension can follow the backend.
+
+`ifndef SNITCH_TRACE_WRITER_SVH_
+`define SNITCH_TRACE_WRITER_SVH_
+
+`ifdef SNITCH_TRACE_GZ
+
+`define SNITCH_TRACE_DECLS \
+  import "DPI-C" function int    tw_open (input string path, input string mode); \
+  import "DPI-C" function void   tw_write(input int h, input string s); \
+  import "DPI-C" function void   tw_close(input int h); \
+  import "DPI-C" function string tw_ext  (input string mode); \
+  string snitch_trace_mode;
+
+// `fmt` is the file name up to the extension, with one format specifier for
+// `id`. It is passed to $sformat on its own and the suffix is concatenated
+// afterwards: Verilator only substitutes a format string that is a literal at
+// the call site, and silently emits it verbatim if it is an expression.
+// The suffix comes from the backend actually selected, so a run with
+// +trace_mode=plain writes a .dasm rather than an uncompressed .dasm.gz that
+// `make traces` would then fail to decompress.
+//
+// tw_open returns -1 on failure; tw_write/tw_close ignore a negative handle,
+// so a failed open degrades to dropping the trace rather than killing the sim.
+`define SNITCH_TRACE_OPEN(handle, fn, fmt, id) \
+  if (!$value$plusargs("trace_mode=%s", snitch_trace_mode)) \
+    snitch_trace_mode = "thr:gz6"; \
+  $sformat(fn, fmt, id); \
+  fn = {fn, tw_ext(snitch_trace_mode)}; \
+  handle = tw_open(fn, snitch_trace_mode)
+
+`define SNITCH_TRACE_WRITE(handle, str) tw_write(handle, str)
+`define SNITCH_TRACE_CLOSE(handle)      tw_close(handle)
+
+`else // plain
+
+`define SNITCH_TRACE_DECLS
+`define SNITCH_TRACE_OPEN(handle, fn, fmt, id) \
+  $sformat(fn, fmt, id); \
+  fn = {fn, "dasm"}; \
+  handle = $fopen(fn, "w")
+`define SNITCH_TRACE_WRITE(handle, str) $fwrite(handle, str)
+`define SNITCH_TRACE_CLOSE(handle)      $fclose(handle)
+
+`endif
+
+`endif // SNITCH_TRACE_WRITER_SVH_

--- a/hw/ip/snitch_test/src/trace_dpi.c
+++ b/hw/ip/snitch_test/src/trace_dpi.c
@@ -1,0 +1,449 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// DPI-C trace writer. Used by the core tracers when the RTL is built with
+// SNITCH_TRACE_GZ (see hw/ip/snitch/include/snitch/trace_writer.svh).
+//
+// Backends, selected by the `mode` string passed to tw_open and overridable
+// at run time with +trace_mode=<mode> or the TW_MODE environment variable
+// (TW_MODE wins; use it where a run wrapper cannot forward a plusarg):
+//
+//   "null"       discard; measures the $sformat cost alone
+//   "plain"      stdio fwrite into a 1 MiB buffer (the pre-DPI behaviour)
+//   "gz<N>"      zlib gzwrite at level N, deflating on the caller's thread
+//   "thr:gz<N>"  producer/consumer: tw_write only memcpys into a block and a
+//                worker thread deflates it. The default and the only backend
+//                that is cheaper per call than plain $fwrite.
+//   "thr:plain"  same handoff without compression
+//
+// Do not use inline "gz<N>": zlib then deflates a whole buffer on the
+// simulator thread every few hundred lines, stalling it for ~1 ms.
+//
+// Tuning: TW_BLKSZ (bytes per block) and TW_NBLK (blocks in flight) size the
+// threaded backend's ring; the default 256 KiB x 2 costs 512 KiB per traced
+// hart. They are not interchangeable. TW_BLKSZ is an efficiency floor: at
+// 256 KiB the worker does one gzwrite per ~430 lines, and shrinking it to
+// 32 KiB costs a rotation and a zlib call often enough to push mean per-write
+// from 9 ns to 1334 ns. TW_NBLK is the burst budget: two is the minimum that
+// lets the producer fill one block while the worker drains the other, and on
+// real traces it measures no worse than four, which only pays off when a burst
+// arrives faster than zlib drains. Raise it if a workload traces in bursts.
+// TW_GZBUF sizes zlib's output buffer (default 64 KiB) and is the knob that
+// governs how much trace is lost if the simulation is killed - the ring is not.
+// TW_LAT=1 records every tw_write's duration and prints percentiles at tw_close.
+//
+// The worker thread assumes the simulation has a spare core. Under a
+// single-core allocation it contends with the simulator and the margin over
+// inline zlib narrows.
+//
+// The number of concurrent tracers is not capped; the slot table grows on
+// demand. What does scale with hart count is one worker thread and one ring
+// per tracer - 512 KiB each by default, so 256 harts hold 128 MB. Trim that
+// with TW_NBLK rather than by shrinking TW_BLKSZ.
+//
+// Compiled as C but pulled in by Verilator's g++, hence the extern "C" guard.
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <pthread.h>
+#include <zlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TW_SLOT0  16        /* initial tracer slots; the table grows as needed */
+#define TW_BUFSZ  (1 << 20)
+#define TW_MAXBLK 8
+
+typedef enum { TW_NULL, TW_PLAIN, TW_GZ, TW_THR } tw_kind_t;
+
+/* ---------- latency instrumentation (TW_LAT=1) ---------- */
+
+static double tw_tsc_hz  = 0.0;   /* calibrated once */
+static double tw_tsc_ovh = 0.0;   /* back-to-back read cost, in ticks */
+
+static double tw_wall(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (double)ts.tv_sec + 1e-9 * (double)ts.tv_nsec;
+}
+
+#if defined(__x86_64__) || defined(__i386__)
+static inline unsigned long long tw_tick(void) {
+  unsigned lo, hi;
+  __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi) :: "memory");
+  return ((unsigned long long)hi << 32) | lo;
+}
+#else
+/* No cycle counter: fall back to the clock, already in ns. */
+static inline unsigned long long tw_tick(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (unsigned long long)ts.tv_sec * 1000000000ULL + (unsigned long long)ts.tv_nsec;
+}
+#endif
+
+static void tw_calibrate(void) {
+  double t0, t1;
+  unsigned long long c0, c1, best = ~0ULL;
+  int i;
+  if (tw_tsc_hz > 0.0) return;
+  t0 = tw_wall(); c0 = tw_tick();
+  while (tw_wall() - t0 < 0.05) { }
+  c1 = tw_tick(); t1 = tw_wall();
+  tw_tsc_hz = (double)(c1 - c0) / (t1 - t0);
+  for (i = 0; i < 2000; i++) {          /* empty-pair floor */
+    unsigned long long a = tw_tick(), b = tw_tick();
+    if (b - a < best) best = b - a;
+  }
+  tw_tsc_ovh = (double)best;
+}
+
+typedef struct {
+  unsigned *v;        /* per-call tick counts */
+  size_t    n, cap;
+} tw_lat_t;
+
+static int tw_lat_on = -1;
+
+static int tw_cmp_u(const void *a, const void *b) {
+  unsigned x = *(const unsigned *)a, y = *(const unsigned *)b;
+  return (x > y) - (x < y);
+}
+
+static double tw_ns(double ticks) {
+  double c = ticks - tw_tsc_ovh;
+  if (c < 0) c = 0;
+  return c * 1e9 / tw_tsc_hz;
+}
+
+static void tw_lat_report(const char *mode, tw_lat_t *L) {
+  static const double pct[] = {50, 90, 99, 99.9, 99.99};
+  double sum = 0;
+  size_t i;
+  unsigned k;
+  if (!L->v || !L->n) return;
+  for (i = 0; i < L->n; i++) sum += L->v[i];
+  qsort(L->v, L->n, sizeof(unsigned), tw_cmp_u);
+  printf("[tw] mode=%s calls=%zu mean_ns=%.0f", mode, L->n, tw_ns(sum / (double)L->n));
+  for (k = 0; k < sizeof pct / sizeof *pct; k++) {
+    size_t j = (size_t)((pct[k] / 100.0) * (double)L->n);
+    if (j >= L->n) j = L->n - 1;
+    printf(" p%g_ns=%.0f", pct[k], tw_ns((double)L->v[j]));
+  }
+  printf(" max_ns=%.0f\n", tw_ns((double)L->v[L->n - 1]));
+  fflush(stdout);
+}
+
+/* ---------- threaded backend ---------- */
+
+/* zlib's own output buffer, which dominates how much is lost if the simulator
+   is killed: it holds compressed bytes, so at ~24x each buffered byte stands
+   for ~24 bytes of trace. 64 KiB keeps that under a megabyte at no measured
+   cost in latency or compression, since the worker thread absorbs the extra
+   write() calls off the simulator's critical path. */
+static unsigned tw_gzbuf(void) {
+  const char *e = getenv("TW_GZBUF");
+  int v = e ? atoi(e) : 0;
+  if (v < 4096) v = 64 * 1024;
+  return (unsigned)v;
+}
+
+typedef struct {
+  char  *blk[TW_MAXBLK];
+  size_t fill[TW_MAXBLK];
+  int    full[TW_MAXBLK], nfull, fhead, ftail;   /* queue of full blocks */
+  int    free_[TW_MAXBLK], nfree, rhead, rtail;  /* queue of free blocks */
+  int    cur; size_t curfill;
+  size_t blksz; int nblk;
+  pthread_t th;
+  pthread_mutex_t m;
+  pthread_cond_t cv_full, cv_free;
+  int stop;
+  gzFile gz; FILE *fp;
+} tw_thr_t;
+
+typedef struct {
+  tw_kind_t kind;
+  FILE     *fp;
+  gzFile    gz;
+  char     *buf;
+  tw_thr_t *thr;
+  tw_lat_t  lat;
+  char      mode[64];
+  int       in_use;
+} tw_slot_t;
+
+/* Grown on demand so the number of traced harts is bounded only by memory.
+   No pointer into this table outlives a single call - every tw_slot_t * is
+   re-derived from the handle - so reallocating it here is safe. The worker
+   thread only ever holds its own tw_thr_t, which is allocated separately. */
+static tw_slot_t *tw_slots;
+static int        tw_nslots;
+
+static void *tw_worker(void *arg) {
+  tw_thr_t *T = (tw_thr_t *)arg;
+  for (;;) {
+    int idx;
+    pthread_mutex_lock(&T->m);
+    while (!T->nfull && !T->stop) pthread_cond_wait(&T->cv_full, &T->m);
+    if (!T->nfull && T->stop) { pthread_mutex_unlock(&T->m); break; }
+    idx = T->full[T->fhead]; T->fhead = (T->fhead + 1) % T->nblk; T->nfull--;
+    pthread_mutex_unlock(&T->m);
+
+    if (T->gz) gzwrite(T->gz, T->blk[idx], (unsigned)T->fill[idx]);
+    else       fwrite(T->blk[idx], 1, T->fill[idx], T->fp);
+
+    pthread_mutex_lock(&T->m);
+    T->free_[T->rtail] = idx; T->rtail = (T->rtail + 1) % T->nblk; T->nfree++;
+    pthread_cond_signal(&T->cv_free);
+    pthread_mutex_unlock(&T->m);
+  }
+  return NULL;
+}
+
+/* Hand the current block to the worker and take a fresh one. Blocks only when
+   every block is still in flight, i.e. when the trace rate outruns zlib. */
+static void tw_thr_rotate(tw_thr_t *T) {
+  pthread_mutex_lock(&T->m);
+  T->fill[T->cur] = T->curfill;
+  T->full[T->ftail] = T->cur; T->ftail = (T->ftail + 1) % T->nblk; T->nfull++;
+  pthread_cond_signal(&T->cv_full);
+  while (!T->nfree) pthread_cond_wait(&T->cv_free, &T->m);
+  T->cur = T->free_[T->rhead]; T->rhead = (T->rhead + 1) % T->nblk; T->nfree--;
+  pthread_mutex_unlock(&T->m);
+  T->curfill = 0;
+}
+
+static tw_thr_t *tw_thr_open(const char *path, int level) {
+  const char *e;
+  int i;
+  tw_thr_t *T = (tw_thr_t *)calloc(1, sizeof *T);
+  if (!T) return NULL;
+  T->blksz = (e = getenv("TW_BLKSZ")) ? (size_t)atol(e) : (256u << 10);
+  T->nblk  = (e = getenv("TW_NBLK"))  ? atoi(e) : 2;
+  if (T->blksz < (4u << 10)) T->blksz = 4u << 10;
+  if (T->nblk < 2) T->nblk = 2;
+  if (T->nblk > TW_MAXBLK) T->nblk = TW_MAXBLK;
+
+  if (level > 0) {
+    char m[16]; snprintf(m, sizeof m, "wb%d", level);
+    T->gz = gzopen(path, m);
+    if (!T->gz) { free(T); return NULL; }
+    gzbuffer(T->gz, tw_gzbuf());
+  } else {
+    T->fp = fopen(path, "wb");
+    if (!T->fp) { free(T); return NULL; }
+    setvbuf(T->fp, NULL, _IOFBF, TW_BUFSZ);
+  }
+  for (i = 0; i < T->nblk; i++) {
+    T->blk[i] = (char *)malloc(T->blksz);
+    if (!T->blk[i]) { /* shrink the ring rather than fail outright */
+      T->nblk = (i < 2) ? 0 : i;
+      break;
+    }
+  }
+  if (T->nblk < 2) {
+    if (T->gz) gzclose(T->gz); else fclose(T->fp);
+    for (i = 0; i < TW_MAXBLK; i++) free(T->blk[i]);
+    free(T);
+    return NULL;
+  }
+  T->cur = 0; T->curfill = 0;
+  for (i = 1; i < T->nblk; i++) { T->free_[T->rtail++] = i; T->nfree++; }
+  T->rtail %= T->nblk;
+  pthread_mutex_init(&T->m, NULL);
+  pthread_cond_init(&T->cv_full, NULL);
+  pthread_cond_init(&T->cv_free, NULL);
+  if (pthread_create(&T->th, NULL, tw_worker, T) != 0) {
+    if (T->gz) gzclose(T->gz); else fclose(T->fp);
+    for (i = 0; i < T->nblk; i++) free(T->blk[i]);
+    free(T);
+    return NULL;
+  }
+  return T;
+}
+
+static void tw_thr_close(tw_thr_t *T) {
+  int i;
+  if (T->curfill) tw_thr_rotate(T);
+  pthread_mutex_lock(&T->m);
+  T->stop = 1;
+  pthread_cond_signal(&T->cv_full);
+  pthread_mutex_unlock(&T->m);
+  pthread_join(T->th, NULL);
+  if (T->gz) gzclose(T->gz); else fclose(T->fp);
+  for (i = 0; i < T->nblk; i++) free(T->blk[i]);
+  pthread_mutex_destroy(&T->m);
+  pthread_cond_destroy(&T->cv_full);
+  pthread_cond_destroy(&T->cv_free);
+  free(T);
+}
+
+/* ---------- DPI surface ---------- */
+
+void tw_close(int h);
+
+static int tw_alloc(void) {
+  int i, n;
+  tw_slot_t *grown;
+  for (i = 0; i < tw_nslots; i++)
+    if (!tw_slots[i].in_use) {
+      memset(&tw_slots[i], 0, sizeof(tw_slot_t));
+      tw_slots[i].in_use = 1;
+      return i;
+    }
+  n = tw_nslots ? tw_nslots * 2 : TW_SLOT0;
+  grown = (tw_slot_t *)realloc(tw_slots, (size_t)n * sizeof(tw_slot_t));
+  if (!grown) return -1;
+  tw_slots = grown;
+  memset(&tw_slots[tw_nslots], 0, (size_t)(n - tw_nslots) * sizeof(tw_slot_t));
+  i = tw_nslots;
+  tw_nslots = n;
+  tw_slots[i].in_use = 1;
+  return i;
+}
+
+/* File suffix matching a mode, so the name on disk always describes the bytes
+   in it. Only the gz-producing backends get ".gz". */
+const char *tw_ext(const char *mode) {
+  const char *env_mode = getenv("TW_MODE");
+  if (env_mode && *env_mode) mode = env_mode;   /* same override as tw_open */
+  if (!strncmp(mode, "thr:gz", 6)) return "dasm.gz";
+  if (mode[0] == 'g' && mode[1] == 'z') return "dasm.gz";
+  return "dasm";
+}
+
+/* Verilator does not run SystemVerilog `final` blocks, so tw_close is never
+   reached there and a gzip stream would be left unterminated - the plain
+   backend survives only because the C runtime flushes stdio at exit. Closing
+   every live tracer from atexit covers that. tw_close clears in_use, so a
+   simulator that *does* run `final` (Questa, VCS) simply finds nothing left. */
+static void tw_atexit(void) {
+  int i;
+  for (i = 0; i < tw_nslots; i++)
+    if (tw_slots[i].in_use) tw_close(i);
+}
+
+int tw_open(const char *path, const char *mode) {
+  static int tw_atexit_armed = 0;
+  int h = tw_alloc();
+  tw_slot_t *s;
+  const char *env_mode = getenv("TW_MODE");
+  /* Some run wrappers take a single positional argument and cannot forward a
+     +trace_mode plusarg, so TW_MODE offers the same choice through the
+     environment and wins when both are given. */
+  if (env_mode && *env_mode) mode = env_mode;
+  if (h < 0) { fprintf(stderr, "[tw] cannot allocate a tracer slot for %s\n", path); return -1; }
+  s = &tw_slots[h];
+  snprintf(s->mode, sizeof s->mode, "%s", mode);
+  if (!tw_atexit_armed) { atexit(tw_atexit); tw_atexit_armed = 1; }
+
+  if (tw_lat_on < 0) { const char *e = getenv("TW_LAT"); tw_lat_on = e && *e == '1'; }
+  if (tw_lat_on) {
+    tw_calibrate();
+    s->lat.cap = 1u << 20;
+    s->lat.v = (unsigned *)malloc(s->lat.cap * sizeof(unsigned));
+    if (!s->lat.v) s->lat.cap = 0;
+  }
+
+  if (!strcmp(mode, "null")) {
+    s->kind = TW_NULL;
+  } else if (!strcmp(mode, "plain")) {
+    s->kind = TW_PLAIN;
+    s->fp = fopen(path, "wb");
+    if (!s->fp) { perror("[tw] fopen"); s->in_use = 0; return -1; }
+    s->buf = (char *)malloc(TW_BUFSZ);
+    if (s->buf) setvbuf(s->fp, s->buf, _IOFBF, TW_BUFSZ);
+  } else if (!strncmp(mode, "thr:", 4)) {
+    int lvl = 0;
+    if (!strncmp(mode + 4, "gz", 2)) { lvl = atoi(mode + 6); if (lvl < 1 || lvl > 9) lvl = 6; }
+    s->kind = TW_THR;
+    s->thr = tw_thr_open(path, lvl);
+    if (!s->thr) { fprintf(stderr, "[tw] cannot open %s\n", path); s->in_use = 0; return -1; }
+  } else if (mode[0] == 'g' && mode[1] == 'z') {
+    char m[16];
+    int lvl = atoi(mode + 2);
+    if (lvl < 1 || lvl > 9) lvl = 6;
+    s->kind = TW_GZ;
+    snprintf(m, sizeof m, "wb%d", lvl);
+    s->gz = gzopen(path, m);
+    if (!s->gz) { fprintf(stderr, "[tw] gzopen %s failed\n", path); s->in_use = 0; return -1; }
+    gzbuffer(s->gz, tw_gzbuf());
+  } else {
+    fprintf(stderr, "[tw] unknown trace_mode '%s'\n", mode);
+    s->in_use = 0;
+    return -1;
+  }
+  return h;
+}
+
+void tw_write(int h, const char *str) {
+  tw_slot_t *s;
+  size_t n;
+  unsigned long long c0 = 0;
+  if (h < 0 || h >= tw_nslots) return;
+  s = &tw_slots[h];
+  if (!s->in_use) return;
+  n = strlen(str);
+  if (tw_lat_on) c0 = tw_tick();
+
+  switch (s->kind) {
+    case TW_NULL:  break;
+    case TW_PLAIN: fwrite(str, 1, n, s->fp); break;
+    case TW_GZ:    gzwrite(s->gz, str, (unsigned)n); break;
+    case TW_THR: {
+      tw_thr_t *T = s->thr;
+      size_t off = 0;
+      /* A line longer than a block is split across blocks; gzip does not care
+         about record boundaries and the reader sees the same byte stream. */
+      while (off < n) {
+        size_t room = T->blksz - T->curfill;
+        size_t take = (n - off < room) ? (n - off) : room;
+        if (!room) { tw_thr_rotate(T); continue; }
+        memcpy(T->blk[T->cur] + T->curfill, str + off, take);
+        T->curfill += take;
+        off += take;
+      }
+      break;
+    }
+  }
+
+  if (tw_lat_on && s->lat.v) {
+    unsigned long long d = tw_tick() - c0;
+    if (s->lat.n == s->lat.cap) {
+      unsigned *nv = (unsigned *)realloc(s->lat.v, s->lat.cap * 2 * sizeof(unsigned));
+      if (nv) { s->lat.v = nv; s->lat.cap *= 2; }
+      else return;
+    }
+    s->lat.v[s->lat.n++] = (d > 0xffffffffULL) ? 0xffffffffu : (unsigned)d;
+  }
+}
+
+void tw_close(int h) {
+  tw_slot_t *s;
+  if (h < 0 || h >= tw_nslots) return;
+  s = &tw_slots[h];
+  if (!s->in_use) return;
+  switch (s->kind) {
+    case TW_NULL:  break;
+    case TW_PLAIN: fclose(s->fp); break;
+    case TW_GZ:    gzclose(s->gz); break;
+    case TW_THR:   tw_thr_close(s->thr); break;
+  }
+  if (tw_lat_on) tw_lat_report(s->mode, &s->lat);
+  free(s->lat.v);
+  free(s->buf);
+  s->in_use = 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/hw/ip/spatz_cc/src/spatz_cc.sv
+++ b/hw/ip/spatz_cc/src/spatz_cc.sv
@@ -7,6 +7,7 @@
 `include "common_cells/assertions.svh"
 `include "common_cells/registers.svh"
 `include "snitch_vm/typedef.svh"
+`include "snitch/trace_writer.svh"
 
 /// Spatz Core Complex (CC)
 /// Contains the Snitch Integer Core + Spatz Vector Unit
@@ -476,6 +477,9 @@ module spatz_cc
   // Tracer
   // --------------------------
   // pragma translate_off
+`ifndef SNITCH_TRACE_DISABLE
+  `SNITCH_TRACE_DECLS
+
   int           f;
   string        fn;
   logic  [63:0] cycle;
@@ -488,8 +492,7 @@ module spatz_cc
     @(posedge clk_i);
     /* verilator lint_on STMTDLY */
     $system("mkdir logs -p");
-    $sformat(fn, "logs/trace_hart_%05x.dasm", hart_id_i);
-    f = $fopen(fn, "w");
+    `SNITCH_TRACE_OPEN(f, fn, "logs/trace_hart_%05x.", hart_id_i);
     $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);
   end
 
@@ -553,7 +556,7 @@ module spatz_cc
         $sformat(trace_entry, "%t %1d %8d 0x%h DASM(%h) #; %s\n",
           $time, cycle, i_snitch.priv_lvl_q, i_snitch.pc_q, i_snitch.inst_data_i,
           snitch_pkg::print_snitch_trace(extras_snitch));
-        $fwrite(f, trace_entry);
+        `SNITCH_TRACE_WRITE(f, trace_entry);
       end
       if (FPEn) begin
         // Trace FPU iff:
@@ -566,7 +569,7 @@ module spatz_cc
           $sformat(trace_entry, "%t %1d %8d 0x%h DASM(%h) #; %s\n",
             $time, cycle, i_snitch.priv_lvl_q, 32'hz, extras_fpu.op_in,
             snitch_pkg::print_fpu_trace(extras_fpu));
-          $fwrite(f, trace_entry);
+          `SNITCH_TRACE_WRITE(f, trace_entry);
         end
       end
     end else begin
@@ -575,9 +578,10 @@ module spatz_cc
   end
 
   final begin
-    $fclose(f);
+    `SNITCH_TRACE_CLOSE(f);
   end
   // verilog_lint: waive-stop always-ff-non-blocking
+`endif // SNITCH_TRACE_DISABLE
   // pragma translate_on
 
   `ASSERT_INIT(BootAddrAligned, BootAddr[1:0] == 2'b00)

--- a/hw/ip/spatz_cc/src/spatz_mempool_cc.sv
+++ b/hw/ip/spatz_cc/src/spatz_mempool_cc.sv
@@ -2,6 +2,8 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
+`include "snitch/trace_writer.svh"
+
 module spatz_mempool_cc
   import snitch_pkg::meta_id_t;
 #(
@@ -377,6 +379,9 @@ module spatz_mempool_cc
   // Tracer
   // --------------------------
   // pragma translate_off
+`ifndef SNITCH_TRACE_DISABLE
+  `SNITCH_TRACE_DECLS
+
   int f;
   string fn;
   logic [63:0] cycle;
@@ -387,8 +392,7 @@ module spatz_mempool_cc
     if(rst_i) begin
       // Format in hex because vcs and vsim treat decimal differently
       // Format with 8 digits because Verilator does not support anything else
-      $sformat(fn, "trace_hart_0x%08x.dasm", hart_id_i);
-      f = $fopen(fn, "w");
+      `SNITCH_TRACE_OPEN(f, fn, "trace_hart_0x%08x.", hart_id_i);
       $display("[Tracer] Logging Hart %d to %s", hart_id_i, fn);
     end
   end
@@ -456,7 +460,7 @@ module spatz_mempool_cc
           $timeformat(-9, 0, "", 10);
           $sformat(trace_entry, "%t %8d 0x%h DASM(%h) #; %s\n",
               $time, cycle, i_snitch.pc_q, i_snitch.inst_data_i, extras_str);
-          $fwrite(f, trace_entry);
+          `SNITCH_TRACE_WRITE(f, trace_entry);
         end
 
         // Reset all stalls when we execute an instruction
@@ -495,9 +499,10 @@ module spatz_mempool_cc
     end
 
   final begin
-    $fclose(f);
+    `SNITCH_TRACE_CLOSE(f);
   end
   // verilog_lint: waive-stop always-ff-non-blocking
+`endif // SNITCH_TRACE_DISABLE
   // pragma translate_on
 
 endmodule

--- a/hw/system/spatz_cluster/Makefile
+++ b/hw/system/spatz_cluster/Makefile
@@ -59,6 +59,26 @@ endif
 # Include Makefrag
 include $(ROOT)/util/Makefrag
 
+# RTL instruction-trace sink, selected at elaboration time. Distinct from the
+# TRACE knob above, which controls snRuntime software tracing.
+#   plain (default)  $fwrite into an uncompressed bin/logs/*.dasm
+#   gz               DPI writer (hw/ip/snitch_test/src/trace_dpi.c) into
+#                    bin/logs/*.dasm.gz. A worker thread does the deflate, so
+#                    the per-write cost is *below* plain $fwrite, and traces
+#                    come out ~32x smaller. Choose the backend at run time
+#                    with +trace_mode=<mode>; the default is thr:gz6.
+#   off              no tracer instantiated at all
+RTL_TRACE ?= plain
+ifeq ($(RTL_TRACE),gz)
+	DEFS += -DSNITCH_TRACE_GZ
+	TRACE_DPI_SRC := ${TB_DIR}/trace_dpi.c
+	TRACE_LDFLAGS := -lz
+else ifeq ($(RTL_TRACE),off)
+	DEFS += -DSNITCH_TRACE_DISABLE
+else ifneq ($(RTL_TRACE),plain)
+$(error RTL_TRACE must be one of: plain, gz, off (got '$(RTL_TRACE)'))
+endif
+
 # QuestaSim
 VSIM      = questa-2021.3-kgf vsim
 VLOG      = questa-2021.3-kgf vlog
@@ -98,6 +118,9 @@ VLT_COBJ += $(VLT_BUILDDIR)/tb/verilator_lib.o
 VLT_COBJ += $(VLT_BUILDDIR)/tb/tb_bin.o
 VLT_COBJ += $(VLT_BUILDDIR)/test/uartdpi/uartdpi.o
 VLT_COBJ += $(VLT_BUILDDIR)/test/bootdata.o
+ifeq ($(RTL_TRACE),gz)
+VLT_COBJ += $(VLT_BUILDDIR)/tb/trace_dpi.o
+endif
 # Sources from verilator root
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated.o
 VLT_COBJ += $(VLT_BUILDDIR)/vlt/verilated_timing.o
@@ -165,7 +188,7 @@ spatz.cleandata:
 # Verilator #
 #############
 
-${VLT_AR}: ${VLT_SOURCES} ${TB_SRCS}
+${VLT_AR}: ${VLT_SOURCES} ${TB_SRCS} ${SVH_SRCS}
 	$(call VERILATE,testharness)
 
 # Quick sanity check, not really meant for simulation.
@@ -186,10 +209,14 @@ $(VLT_BUILDDIR)/test/uartdpi/uartdpi.o: test/uartdpi/uartdpi.c
 	mkdir -p $(dir $@)
 	$(CC) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
 
+$(VLT_BUILDDIR)/tb/trace_dpi.o: $(TB_DIR)/trace_dpi.c
+	mkdir -p $(dir $@)
+	$(CC) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
+
 # Link verilated archive wich $(VLT_COBJ)
 bin/spatz_cluster.vlt: $(VLT_AR) $(VLT_COBJ) ${VLT_BUILDDIR}/lib/libfesvr.a
 	mkdir -p $(dir $@)
-	$(CXX) $(LDFLAGS) -L ${VLT_BUILDDIR}/lib -o $@ $(VLT_COBJ) $(VLT_AR) -lpthread -lfesvr -lutil -latomic
+	$(CXX) $(LDFLAGS) -L ${VLT_BUILDDIR}/lib -o $@ $(VLT_COBJ) $(VLT_AR) -lpthread -lfesvr -lutil -latomic ${TRACE_LDFLAGS}
 
 # Clean all build directories and temporary files for Verilator simulation
 .PHONY: clean.vlt
@@ -201,11 +228,14 @@ clean.vlt:
 # Modelsim #
 ############
 
-${VSIM_BUILDDIR}/compile.vsim.tcl: test/bootrom.bin $(VSIM_SOURCES) ${TB_SRCS} ${TB_DIR}/rtl_lib.cc ${TB_DIR}/common_lib.cc test/bootdata.cc test/bootrom.bin
+${VSIM_BUILDDIR}/compile.vsim.tcl: test/bootrom.bin $(VSIM_SOURCES) ${TB_SRCS} ${TB_DIR}/rtl_lib.cc ${TB_DIR}/common_lib.cc test/bootdata.cc test/bootrom.bin ${TRACE_DPI_SRC} ${SVH_SRCS}
 	vlib $(dir $@)
 	${BENDER} script vsim ${VSIM_BENDER} ${DEFS} --vlog-arg="${VLOG_FLAGS} -work $(dir $@) " > $@
 	echo '${VLOG} -work $(dir $@) ${TB_DIR}/rtl_lib.cc ${TB_DIR}/common_lib.cc test/bootdata.cc -ccflags "-std=c++17 -I${MKFILE_DIR}/test -I${MKFILE_DIR}/work/include -I${TB_DIR}"' >> $@
 	echo '${VLOG} -work $(dir $@) test/uartdpi/uartdpi.c -ccflags "-Itest/uartdpi"' >> $@
+ifeq ($(RTL_TRACE),gz)
+	echo '${VLOG} -work $(dir $@) ${TB_DIR}/trace_dpi.c -ccflags "-O2"' >> $@
+endif
 	echo 'return 0' >> $@
 
 bin/spatz_cluster.vsim: ${VSIM_BUILDDIR}/compile.vsim.tcl work/lib/libfesvr_vsim.a
@@ -220,12 +250,12 @@ clean.vsim:
 #######
 # @IIS: vcs-2020.12 make bin/spatz_cluster.vcs
 ## Build compilation script and compile all sources for VCS simulation
-bin/spatz_cluster.vcs: test/bootrom.bin work-vcs/compile.sh work/lib/libfesvr_vcs.a ${TB_DIR}/common_lib.cc test/bootdata.cc test/bootrom.bin test/uartdpi/uartdpi.c
+bin/spatz_cluster.vcs: test/bootrom.bin work-vcs/compile.sh work/lib/libfesvr_vcs.a ${TB_DIR}/common_lib.cc test/bootdata.cc test/bootrom.bin test/uartdpi/uartdpi.c ${TRACE_DPI_SRC}
 	mkdir -p bin
 	# Default to fast simulation flags, use `-debug_access+all +vcs+fsdbon` for waveform debugging
 	vcs -Mlib=work-vcs -Mdir=work-vcs -O2 -debug_access=r -debug_region=1,tb_bin -kdb -o $@ -j4 -cc $(CC) -cpp $(CXX) \
-		-assert disable_cover -override_timescale=1ns/1ps -full64 tb_bin ${TB_DIR}/rtl_lib.cc ${TB_DIR}/common_lib.cc test/bootdata.cc test/uartdpi/uartdpi.c \
-		-CFLAGS "-I${MKFILE_DIR} -I${MKFILE_DIR}/test -I${FESVR}/include -I${TB_DIR} -Itest/uartdpi" -LDFLAGS "-L${FESVR}/lib" -lfesvr_vcs -lutil
+		-assert disable_cover -override_timescale=1ns/1ps -full64 tb_bin ${TB_DIR}/rtl_lib.cc ${TB_DIR}/common_lib.cc test/bootdata.cc test/uartdpi/uartdpi.c ${TRACE_DPI_SRC} \
+		-CFLAGS "-I${MKFILE_DIR} -I${MKFILE_DIR}/test -I${FESVR}/include -I${TB_DIR} -Itest/uartdpi" -LDFLAGS "-L${FESVR}/lib" -lfesvr_vcs -lutil ${TRACE_LDFLAGS}
 
 ## Clean all build directories and temporary files for VCS simulation
 clean.vcs:

--- a/util/Makefrag
+++ b/util/Makefrag
@@ -33,6 +33,9 @@ MATCH_END := '/+incdir+/ s/$$/\/*\/*/'
 MATCH_BGN := 's/+incdir+//g'
 SED_SRCS  := sed -e ${MATCH_END} -e ${MATCH_BGN}
 TB_SRCS   := $(wildcard ${ROOT}/hw/ip/snitch_test/*.sv)
+# Included headers are not in the bender file list, so a build would not
+# otherwise notice an edit to one and would silently reuse a stale model.
+SVH_SRCS  := $(wildcard ${ROOT}/hw/ip/snitch/include/snitch/*.svh)
 TB_DIR    := ${ROOT}/hw/ip/snitch_test/src
 
 VSIM_BENDER   += -t test -t rtl -t simulation -t spatz -t spatz_test -t snitch_test ${BENDER_CFG_TARGETS}
@@ -134,23 +137,27 @@ define QUESTASIM
 	@! grep -P "Errors: [1-9]*," $(dir $<)vsim.log
 	@mkdir -p bin
 	@echo "#!/bin/bash" > $@
-	@echo 'echo `realpath $$1` > bin/logs/.rtlbinary' >> $@
+	@echo '# Last argument is the RISC-V binary; anything before it is passed' >> $@
+	@echo '# through to vsim, so plusargs such as +trace_mode=plain work here.' >> $@
+	@echo 'binary="$${@: -1}"' >> $@
+	@echo 'echo `realpath "$$binary"` > bin/logs/.rtlbinary' >> $@
 	@echo '${VSIM} +permissive ${VSIM_FLAGS_SHELL} -work ${MKFILE_DIR}/${VSIM_BUILDDIR} -c \
-				-ldflags "-Wl,-rpath,${FESVR}/lib -L${FESVR}/lib -lfesvr_vsim -lutil" \
-				$1 +permissive-off ++$$1' >> $@
+				-ldflags "-Wl,-rpath,${FESVR}/lib -L${FESVR}/lib -lfesvr_vsim -lutil ${TRACE_LDFLAGS}" \
+				"$${@:1:$$#-1}" $1 +permissive-off ++"$$binary"' >> $@
 	@chmod +x $@
 	@echo "#!/bin/bash" > $@.gui
-	@echo 'echo `realpath $$1` > bin/logs/.rtlbinary' >> $@
+	@echo 'binary="$${@: -1}"' >> $@.gui
+	@echo 'echo `realpath "$$binary"` > bin/logs/.rtlbinary' >> $@.gui
 	@echo '${VSIM} +permissive ${VSIM_FLAGS_GUI} -work ${MKFILE_DIR}/${VSIM_BUILDDIR} \
-				-ldflags "-Wl,-rpath,${FESVR}/lib -L${FESVR}/lib -lfesvr_vsim -lutil" \
-				$1 +permissive-off ++$$1' >> $@.gui
+				-ldflags "-Wl,-rpath,${FESVR}/lib -L${FESVR}/lib -lfesvr_vsim -lutil ${TRACE_LDFLAGS}" \
+				"$${@:1:$$#-1}" $1 +permissive-off ++"$$binary"' >> $@.gui
 	@chmod +x $@.gui
 endef
 
 #######
 # VCS #
 #######
-work-vcs/compile.sh: ${VSIM_SOURCES} ${TB_SRCS}
+work-vcs/compile.sh: ${VSIM_SOURCES} ${TB_SRCS} ${SVH_SRCS}
 	mkdir -p work-vcs
 	${BENDER} script vcs ${VSIM_BENDER} ${DEFS} --vlog-arg="${VLOGAN_FLAGS}" --vcom-arg="${VHDLAN_FLAGS}" > $@
 	chmod +x $@
@@ -161,10 +168,14 @@ work-vcs/compile.sh: ${VSIM_SOURCES} ${TB_SRCS}
 ########
 
 .PHONY: traces
-traces: $(shell (ls bin/logs/trace_hart_*.dasm 2>/dev/null | sed 's/\.dasm/\.txt/') || echo "")
+traces: $(shell (ls bin/logs/trace_hart_*.dasm bin/logs/trace_hart_*.dasm.gz 2>/dev/null | sed 's/\.dasm\.gz/\.txt/;s/\.dasm/\.txt/') || echo "")
 
 bin/logs/trace_hart_%.txt: bin/logs/trace_hart_%.dasm ${ROOT}/util/gen_trace.py
 	$(DASM) < $< | $(PYTHON) ${ROOT}/util/gen_trace.py > $@
+
+# RTL_TRACE=gz builds emit .dasm.gz; decompress on the way into spike-dasm.
+bin/logs/trace_hart_%.txt: bin/logs/trace_hart_%.dasm.gz ${ROOT}/util/gen_trace.py
+	gzip -dc $< | $(DASM) | $(PYTHON) ${ROOT}/util/gen_trace.py > $@
 
 # make annotate
 # Generate source-code interleaved traces for all harts. Reads the binary from
@@ -172,4 +183,4 @@ bin/logs/trace_hart_%.txt: bin/logs/trace_hart_%.dasm ${ROOT}/util/gen_trace.py
 bin/logs/trace_hart_%.s: bin/logs/trace_hart_%.txt ${ROOT}/util/trace/annotate.py
 	$(PYTHON) ${ROOT}/util/trace/annotate.py -q -o $@ $(BINARY) $<
 BINARY ?= $(shell cat bin/logs/.rtlbinary)
-annotate: $(shell (ls bin/logs/trace_hart_*.dasm 2>/dev/null | sed 's/\.dasm/\.s/') || echo "")
+annotate: $(shell (ls bin/logs/trace_hart_*.dasm bin/logs/trace_hart_*.dasm.gz 2>/dev/null | sed 's/\.dasm\.gz/\.s/;s/\.dasm/\.s/') || echo "")


### PR DESCRIPTION
 ### Summary

  Adds `RTL_TRACE` to select the instruction-trace backend in simulation:
 *  `plain` (default, unchanged `$fwrite` to `.dasm`)
 *  `gz` (DPI writer producing  `.dasm.gz`)
 *  `off` (no tracer)

A compression ratio of 34x is reached on the traces without regressing simulation time.

### Motivation

The uncompressed per-hart tracers in `spatz_cc` and `spatz_mempool_cc` can accumulate many Gigabytes of data which are potentially not needed anyhow.
The generated traces are highly compressible: A 1.4 GB dasm trace compresses to 40 MB with gzip-6 (34x).

### What changed
- **`hw/ip/snitch_test/src/trace_dpi.c`**: new DPI writer. 
Backends are `thr:gz<N>` (default `thr:gz6`),  `thr:plain`, `gz<N>`, `plain` and `null`. 
 - **`hw/ip/snitch/include/snitch/trace_writer.svh`**:  `SNITCH_TRACE_GZ` selects the DPI writer, `SNITCH_TRACE_DISABLE` removes the tracer.  - **`spatz_cc.sv` / `spatz_mempool_cc.sv`**: Updated to use new tracer
- **`hw/system/spatz_cluster/Makefile`, `util/Makefrag`**: `RTL_TRACE`  wires the  defines, added required DPI compiles

### Verification

Verified on QuestaSim 2021.3_2, Verilator 5.020 (GCC 11.2.0) and VCS 2022.06, default cluster config:  
Traces decompress byte-identical to the same run under plain, 23.5 MiB → 1015 KiB (23.7x).

Compression does not affect simulation time:
In this implementation, the compression task is offloaded to a worker thread, so it never stalls the main simulation. 
Due to the optimized DPI, the per-write latency even drops from 155ns to 61ns compared to `$fwire`.

Behavior on crashes was investigated:
On `SIGKILL`, the `.gz` still decompresses; every complete line is intact and in order; only the final line is cut, and ~920 KB is lost against  ~690 KB  for plain `$fwrite`, which buffers too.


###  Notes
This work was supported by Claudio (claude.ai).